### PR TITLE
Pass over odd dependency import error

### DIFF
--- a/pelix/framework.py
+++ b/pelix/framework.py
@@ -1621,3 +1621,6 @@ def normalize_path():
         except AttributeError:
             # builtin modules don't have a __path__
             pass
+        except ImportError:
+            pass
+            


### PR DESCRIPTION
I am currently using 
python-scipy package in ubuntu 14.04. When the package is intstalled, python-six is pulled in as a dependency. The six package contains the windows library winreg and causes an import error in the normalize_path method. Here is error https://gist.github.com/debovis/a8dc9e38f54a5adc87e523d04aa12e83 coming from six.moves.winreg import. 