### PR TITLE
Initial checkin of API addition, implementation and test of EventListenerHook

### DIFF
--- a/pelix/framework.py
+++ b/pelix/framework.py
@@ -649,7 +649,7 @@ class Framework(Bundle):
         self._registry = ServiceRegistry(self)
         self.__unregistering_services = {}
         
-                # Event dispatcher
+        # Event dispatcher
         self._dispatcher = EventDispatcher(self._registry)
 
         # The wait_for_stop event (initially stopped)

--- a/pelix/framework.py
+++ b/pelix/framework.py
@@ -645,12 +645,12 @@ class Framework(Bundle):
         # Bundles lock
         self.__bundles_lock = threading.RLock()
 
-        # Event dispatcher
-        self._dispatcher = EventDispatcher()
-
         # Service registry
         self._registry = ServiceRegistry(self)
         self.__unregistering_services = {}
+        
+                # Event dispatcher
+        self._dispatcher = EventDispatcher(self._registry)
 
         # The wait_for_stop event (initially stopped)
         self._fw_stop_event = threading.Event()
@@ -1441,6 +1441,7 @@ class BundleContext(object):
                '''
                # ...
 
+        :param bundle_context:  This bundle context
         :param listener: The listener to register
         :param ldap_filter: Filter that must match the service properties
                             (optional, None to accept all services)
@@ -1448,7 +1449,7 @@ class BundleContext(object):
                               (optional, None to accept all services)
         :return: True if the listener has been successfully registered
         """
-        return self.__framework._dispatcher.add_service_listener(
+        return self.__framework._dispatcher.add_service_listener(self,
             listener, specification, ldap_filter)
 
     def get_all_service_references(self, clazz, ldap_filter=None):

--- a/pelix/internals/hooks.py
+++ b/pelix/internals/hooks.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+EventListenerHook for Pelix.
+
+:author: Scott Lewis
+:copyright: Copyright 2017, Scott Lewis
+:license: Apache License 2.0
+:version: 0.7.0
+
+..
+
+    Copyright 2017 Scott Lewis
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+# Module version
+__version_info__ = (0, 7, 0)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+# ------------------------------------------------------------------------------
+
+from collections import MutableMapping, MutableSequence
+
+class ShrinkableList(MutableSequence):
+    '''
+    LIst where items 
+    can be removed, but nothing 
+    can be added.  For use in ShinkableMap
+    '''
+    def __init__(self, delegate):
+        self._delegate = delegate
+
+    def __len__(self):
+        return len(self._delegate)
+    
+    def __getitem__(self, index):
+        return self._delegate[index]
+    
+    def __delitem__(self, index):
+        del self._delegate[index]
+    
+    def __setitem__(self, index, value):
+        raise IndexError
+    
+    def insert(self, index, value):
+        raise IndexError
+    
+    def __str__(self):
+        return str(self._delegate)
+    
+class ShrinkableMap(MutableMapping):
+    '''
+    Map where item->value mappings 
+    can be removed, but nothing 
+    can be added.  For use in EventListenerHook
+    '''
+    def __init__(self, delegate):
+        self._delegate = delegate
+        
+    def __getitem__(self, key):
+        return self._delegate[key]
+    
+    def __setitem__(self, key, value):
+        raise IndexError
+    
+    def __delitem__(self, key):
+        del self._delegate[key]
+        
+    def __iter__(self):
+        return self._delegate.__iter__()
+    
+    def __len__(self):
+        return len(self._delegate)
+    
+class ListenerInfo(object):
+    """
+    Keeps information about a listener
+    """
+    # Try to reduce memory footprint (stored instances)
+    __slots__ = ('bundle_context', 'listener', 'specification', 'ldap_filter')
+
+    def __init__(self, bundle_context, listener, specification, ldap_filter):
+        """
+        Sets up members
+
+        :param bundle_context: Bundle context
+        :param listener: Listener instance
+        :param specification: Specification to listen to
+        :param ldap_filter: LDAP filter on service properties
+        """
+        self.bundle_context = bundle_context
+        self.listener = listener
+        self.specification = specification
+        self.ldap_filter = ldap_filter
+
+class EventListenerHook(object):
+    """
+    Event listener hook interface prototype.  The method in this class must be
+    overriden for a service event listener hook to be called via whiteboard p
+    pattern
+    """
+    def event(self,service_event,listener_dict):
+        pass
+    
+

--- a/pelix/internals/hooks.py
+++ b/pelix/internals/hooks.py
@@ -6,7 +6,7 @@ EventListenerHook for Pelix.
 :author: Scott Lewis
 :copyright: Copyright 2017, Scott Lewis
 :license: Apache License 2.0
-:version: 0.7.0
+:version: 0.7.1
 
 ..
 

--- a/pelix/internals/registry.py
+++ b/pelix/internals/registry.py
@@ -847,15 +847,11 @@ class EventDispatcher(object):
         # Get EventListenerHooks service refs from registry    
         hook_refs = self._registry.find_service_references(SERVICE_EVENT_LISTENER_HOOK)
         # only do something if there are some hook_refs
-        if hook_refs and len(hook_refs) > 0:
+        if hook_refs:
             d = dict()
             for listener in listeners:
                 bc = listener.bundle_context
-                try:
-                    lst = d[bc]
-                    lst.append(listener)
-                except KeyError:
-                    d[bc] = [listener]
+                d.setdefault(bc,[]).append(listener)
 
             hdict = dict()
             for k,v in d.items():

--- a/pelix/services/__init__.py
+++ b/pelix/services/__init__.py
@@ -32,6 +32,9 @@ __version__ = ".".join(str(x) for x in __version_info__)
 # Documentation strings format
 __docformat__ = "restructuredtext en"
 
+# Service Registry Hooks
+
+SERVICE_EVENT_LISTENER_HOOK = "pelix.internal.hooks.EventListenerHook"
 # ------------------------------------------------------------------------------
 
 FACTORY_EVENT_ADMIN = "pelix-services-eventadmin-factory"

--- a/samples/hook_test.py
+++ b/samples/hook_test.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+# -- Content-Encoding: UTF-8 --
+"""
+Hook Test
+
+:author: Scott Lewis
+:copyright: Copyright 2017, Scott Lewis
+:license: Apache License 2.0
+
+..
+
+    Copyright 2017 Scott Lewis
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+# Pelix remote services constants
+from pelix.constants import BundleActivator
+
+from pelix.services import SERVICE_EVENT_LISTENER_HOOK
+# ------------------------------------------------------------------------------
+
+# Module version
+__version_info__ = (0, 7, 0)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+# ------------------------------------------------------------------------------
+
+class EventListenerHookImpl(object):
+    
+    def __init__(self,context):
+        self._context = context
+        self._count = 0
+        
+    def event(self,service_event,listener_dict):
+        print('EventListenerHookSample: service_event='+str(service_event)+",listener_dict="+str(listener_dict))
+        # remove it if it's our service context and it's the 3rd time through the hook
+        if self._context in listener_dict and self._count > 1:
+            print('EventListenerHookSample removing our service listener so it will not be notified')
+            listener_dict.pop(self._context)
+        else:
+            self._count += 1
+        
+
+# ------------------------------------------------------------------------------
+
+class ServiceEventListenerImpl(object):
+    def service_changed(self,service_event):
+        print("MyServiceEventListener event="+str(service_event))
+        
+@BundleActivator
+class Activator(object):
+    def __init__(self):
+        self.__sel = ServiceEventListenerImpl()
+        self.__registration = None
+
+    def start(self, context):
+        # Add service listener
+        context.add_service_listener(self.__sel)
+        # register EventListenerHook as service
+        self.__registration = context.register_service(
+            SERVICE_EVENT_LISTENER_HOOK, EventListenerHookImpl(context), None)
+
+    def stop(self, context):
+        # Unregister the EventListenerHook
+        self.__registration.unregister()
+        self.__registration = None
+        # Remove service listener
+        context.remove_service_listener(self.__sel)

--- a/samples/run_handler.py
+++ b/samples/run_handler.py
@@ -63,6 +63,7 @@ def main():
     """
     # Create the framework
     fw = pelix.framework.create_framework(('pelix.ipopo.core',
+#                                           'samples.hook_test',
                                            'pelix.shell.core',
                                            'pelix.shell.ipopo',
                                            'pelix.shell.console',


### PR DESCRIPTION
Initial checkin of API addition, implementation and test of EventListenerHook   
The test consists of a new module: samples.hook_test.py which is loaded by the
samples.run_handler.py.  See line 66 in run_handler.py to enable  hook_test.  Didn't know how/whether you wanted this integrated with framework testing.

First step for addressing issue #60 