### PR TITLE
Improved fix for iPOPO issue 100

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - sudo prosodyctl register user1 localhost foobar
   - sudo prosodyctl register user2 localhost foobar
   - sudo prosodyctl restart
-  - curl -qL http://apache.mediamirrors.org/karaf/4.2.0/apache-karaf-4.2.0.tar.gz | tar xz -C /tmp
+  - curl -qL http://apache.mediamirrors.org/karaf/4.2.1/apache-karaf-4.2.1.tar.gz | tar xz -C /tmp
   - pip install nose coverage coverage_enable_subprocess coveralls
   - pip install https://github.com/tcalmant/jsonrpclib/archive/master.zip
   - pip install -r requirements.txt


### PR DESCRIPTION
This provides an improved/general fix for issue 100:  https://github.com/tcalmant/ipopo/issues/100

What was happening was that the thread used to read remote service discovery messages from Java (in the py4j provider in rsa.providers.distribution.py4j.py) was not being cleanly shutdown upon framework shutdown (i.e. distribution provider invalidate).   With this addition it is now being shut down cleanly and I am unable to reproduce the shutdown hang.