### PR TITLE
Small fixes related to RSA updates

### DIFF
--- a/pelix/rsa/shell.py
+++ b/pelix/rsa/shell.py
@@ -28,8 +28,9 @@ Remote Service Admin Shell Commands
 import os
 from threading import RLock
 from traceback import print_exception
-from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple, TypeVar, cast
+from typing import Any, List, Optional, Set, Tuple, TypeVar, cast
 
+import pelix.rsa.remoteserviceadmin as rsa_impl
 from pelix.constants import SERVICE_ID
 from pelix.framework import BundleContext
 from pelix.internals.registry import ServiceReference
@@ -65,9 +66,6 @@ from pelix.rsa.providers.distribution import (
 )
 from pelix.shell import ShellCommandMethod, ShellCommandsProvider, ShellUtils
 from pelix.shell.beans import ShellSession
-
-if TYPE_CHECKING:
-    import pelix.rsa.remoteserviceadmin as rsa_impl
 
 # ------------------------------------------------------------------------------
 # Module version

--- a/pelix/rsa/topologymanagers/__init__.py
+++ b/pelix/rsa/topologymanagers/__init__.py
@@ -27,11 +27,13 @@ Topology Manager API
 """
 
 import logging
+from typing import Any, Dict, List, Optional, cast
 
+import pelix.rsa.remoteserviceadmin as rsa_impl
 from pelix.framework import BundleContext
-from pelix.internals.registry import ServiceReference
 from pelix.internals.events import ServiceEvent
 from pelix.internals.hooks import EventListenerHook
+from pelix.internals.registry import ServiceReference
 from pelix.ipopo.decorators import Invalidate, Provides, Requires, Validate
 from pelix.rsa import (
     SERVICE_EXPORTED_INTERFACES,
@@ -44,16 +46,12 @@ from pelix.rsa import (
 )
 from pelix.rsa.endpointdescription import EndpointDescription
 from pelix.rsa.providers.discovery import (
-    EndpointAdvertiser,
     SERVICE_ENDPOINT_LISTENER,
+    EndpointAdvertiser,
     EndpointEvent,
     EndpointEventListener,
 )
 from pelix.services import SERVICE_EVENT_LISTENER_HOOK
-from typing import TYPE_CHECKING, Any, Dict, List, cast, Optional
-
-if TYPE_CHECKING:
-    import pelix.rsa.remoteserviceadmin as rsa_impl
 
 # ------------------------------------------------------------------------------
 # Module version
@@ -164,7 +162,7 @@ class TopologyManager(EventListenerHook, RemoteServiceAdminListener, EndpointEve
         self._handle_event(service_event)
 
     def _advertise_endpoint(self, ed: EndpointDescription) -> None:
-        for adv in self._advertisers:
+        for adv in self._advertisers or []:
             try:
                 adv.advertise_endpoint(ed)
             except:
@@ -175,7 +173,7 @@ class TopologyManager(EventListenerHook, RemoteServiceAdminListener, EndpointEve
                 )
 
     def _update_endpoint(self, ed: EndpointDescription) -> None:
-        for adv in self._advertisers:
+        for adv in self._advertisers or []:
             try:
                 adv.update_endpoint(ed)
             except:
@@ -186,7 +184,7 @@ class TopologyManager(EventListenerHook, RemoteServiceAdminListener, EndpointEve
                 )
 
     def _unadvertise_endpoint(self, ed: EndpointDescription) -> None:
-        for adv in self._advertisers:
+        for adv in self._advertisers or []:
             try:
                 adv.unadvertise_endpoint(ed.get_id())
             except:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ jsonrpclib-pelix>=0.4.3
 redis>=2.10
 kazoo==2.8.0
 paho-mqtt>=2
-zeroconf==0.19
+zeroconf==0.19.1
 osgiservicebridge>=1.5.1
 pyyaml>=6.0
 etcd3>=0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ paho-mqtt>=2
 zeroconf==0.19.1
 osgiservicebridge>=1.5.1
 pyyaml>=6.0
-etcd3>=0.12.0
+etcd3-fc>=0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 jsonrpclib-pelix>=0.4.3
 redis>=2.10
 kazoo==2.8.0
-paho-mqtt>=1.6.1
+paho-mqtt>=2
 zeroconf==0.19
-python-etcd>=0.4.5
 osgiservicebridge>=1.5.1
 pyyaml>=6.0
 etcd3>=0.12.0

--- a/tests-infra/xmpp/compose.yaml
+++ b/tests-infra/xmpp/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   xmpp:
     image: ejabberd/ecs:latest


### PR DESCRIPTION
* Updated requirements.txt to match new requirements
  * **Note:** we have an issue with protobuf version incompatibilities between osgiservicebridge and etcd3
* Fixed `rsa_impl` imports: initially used in type annotations only and therefore loaded with TYPE_CHECKING, they are now imported all the time as its types are used in `cast()` calls
* Fixed a warning in a test infrastructure composition file