### PR TITLE
Updated osgiservicebridge to 1.5.7 because of protobuf version issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ redis>=2.10
 kazoo==2.8.0
 paho-mqtt>=2
 zeroconf==0.19.1
-osgiservicebridge>=1.5.6
+osgiservicebridge>=1.5.7
 pyyaml>=6.0
 etcd3>=0.12.0


### PR DESCRIPTION
After additional testing, an issue with protobuf version was found and to osgiservicebridge has new workaround and version 1.5.7