### PR TITLE
HTTP refactoring

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -67,6 +67,12 @@ All versions up to 3.2.1 are affected.
   handle (a `set`, a custom object, ...) raised a `TypeError` that aborted the
   export of the whole endpoint. Such values are now logged and sent as strings
 
+### HTTP service
+
+* Shared code of synchronous and asynchronous HTTP services has been moved to
+  a common base class in the `pelix.http._base` module. It is intended for
+  internal use only
+
 ### Tests
 
 * Added tests for the Zeroconf/mDNS property serialization
@@ -74,6 +80,7 @@ All versions up to 3.2.1 are affected.
 * Added tests for the handling of PIDs by the Configuration Admin persistence
 * Added tests for the content of the HTTP error pages
 * Added tests for the rejection of XML document type declarations
+* Added tests for the code shared by the HTTP service implementations
 
 ## iPOPO 3.2.1
 

--- a/pelix/http/__init__.py
+++ b/pelix/http/__init__.py
@@ -29,8 +29,9 @@ Defines the interfaces that must respect HTTP service implementations.
 
 import asyncio
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from enum import Enum
-from typing import IO, Any, Dict, Iterable, List, Optional, Protocol, Tuple, runtime_checkable
+from typing import IO, Any, Protocol, runtime_checkable
 
 from pelix.constants import Specification
 from pelix.utilities import to_bytes
@@ -192,7 +193,7 @@ class AbstractHTTPServletRequest(ABC):
         ...
 
     @abstractmethod
-    def get_client_address(self) -> Tuple[str, int]:
+    def get_client_address(self) -> tuple[str, int]:
         """
         Returns the address of the client
 
@@ -212,7 +213,7 @@ class AbstractHTTPServletRequest(ABC):
         ...
 
     @abstractmethod
-    def get_headers(self) -> Dict[str, Any]:
+    def get_headers(self) -> dict[str, Any]:
         """
         Returns a copy all headers, with a dictionary interface
 
@@ -276,7 +277,7 @@ class AbstractHTTPServletResponse(ABC):
     """
 
     @abstractmethod
-    def set_response(self, code: int, message: Optional[str] = None) -> None:
+    def set_response(self, code: int, message: str | None = None) -> None:
         """
         Sets the response line.
         This method should be the first called when sending an answer.
@@ -340,8 +341,8 @@ class AbstractHTTPServletResponse(ABC):
         self,
         http_code: int,
         content: str,
-        mime_type: Optional[str] = "text/html",
-        http_message: Optional[str] = None,
+        mime_type: str | None = "text/html",
+        http_message: str | None = None,
         content_length: int = -1,
     ) -> None:
         """
@@ -394,7 +395,7 @@ class AbstractAsyncHTTPServletRequest(ABC):
         ...
 
     @abstractmethod
-    def get_client_address(self) -> Tuple[str, int]:
+    def get_client_address(self) -> tuple[str, int]:
         """
         Returns the address of the client
 
@@ -414,7 +415,7 @@ class AbstractAsyncHTTPServletRequest(ABC):
         ...
 
     @abstractmethod
-    async def get_headers(self) -> Dict[str, Any]:
+    async def get_headers(self) -> dict[str, Any]:
         """
         Returns a copy all headers, with a dictionary interface
 
@@ -499,7 +500,7 @@ class AbstractAsyncHTTPServletResponse(ABC):
     """
 
     @abstractmethod
-    def set_response(self, code: int, message: Optional[str] = None) -> None:
+    def set_response(self, code: int, message: str | None = None) -> None:
         """
         Sets the response line.
         This method should be the first called when sending an answer.
@@ -585,8 +586,8 @@ class AbstractAsyncHTTPServletResponse(ABC):
         self,
         http_code: int,
         content: str,
-        mime_type: Optional[str] = "text/html",
-        http_message: Optional[str] = None,
+        mime_type: str | None = "text/html",
+        http_message: str | None = None,
         content_length: int = -1,
     ) -> None:
         """
@@ -680,7 +681,7 @@ class WebSocketSession(Protocol):
     Websocket session helper
     """
 
-    def get_client_address(self) -> Tuple[str, int]:
+    def get_client_address(self) -> tuple[str, int]:
         """
         Returns the address of the client
 
@@ -824,7 +825,7 @@ class HTTPService(Protocol):
     HTTP service interface
     """
 
-    def get_access(self) -> Tuple[str, int]:
+    def get_access(self) -> tuple[str, int]:
         """
         Retrieves the (address, port) tuple to access the server
         """
@@ -846,7 +847,7 @@ class HTTPService(Protocol):
         """
         ...
 
-    def get_registered_paths(self) -> List[str]:
+    def get_registered_paths(self) -> list[str]:
         """
         Returns the paths registered by servlets
 
@@ -854,7 +855,7 @@ class HTTPService(Protocol):
         """
         ...
 
-    def get_servlet(self, path: Optional[str]) -> Optional[Tuple[Servlet, Dict[str, Any], str, ServletType]]:
+    def get_servlet(self, path: str | None) -> tuple[Servlet, dict[str, Any], str, ServletType] | None:
         """
         Retrieves the servlet matching the given path and its parameters.
         Returns None if no servlet matches the given path.
@@ -887,7 +888,7 @@ class HTTPService(Protocol):
         self,
         path: str,
         servlet: Servlet,
-        parameters: Optional[Dict[str, Any]] = None,
+        parameters: dict[str, Any] | None = None,
         servlet_type: ServletType = ServletType.SYNC,
     ) -> bool:
         """
@@ -902,7 +903,7 @@ class HTTPService(Protocol):
         """
         ...
 
-    def unregister(self, path: Optional[str], servlet: Optional[Servlet] = None) -> bool:
+    def unregister(self, path: str | None, servlet: Servlet | None = None) -> bool:
         """
         Unregisters the servlet for the given path
 

--- a/pelix/http/__init__.py
+++ b/pelix/http/__init__.py
@@ -485,13 +485,13 @@ class AbstractAsyncWriter(ABC):
         :param raw: Data to write
         :return: Number of bytes written
         """
-        ...
+        ...  # noqa: PIE790
 
     async def flush(self) -> None:
         """
         Flushes the buffer if any
         """
-        ...
+        ...  # noqa: PIE790
 
 
 class AbstractAsyncHTTPServletResponse(ABC):

--- a/pelix/http/_base.py
+++ b/pelix/http/_base.py
@@ -41,11 +41,10 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, cast
 
-import pelix.http as http
-import pelix.ipopo.constants as constants
 import pelix.remote
-import pelix.utilities as utilities
+from pelix import http, utilities
 from pelix.internals.registry import ServiceReference
+from pelix.ipopo import constants
 from pelix.ipopo.decorators import HiddenProperty, Property
 
 # ------------------------------------------------------------------------------

--- a/pelix/http/_base.py
+++ b/pelix/http/_base.py
@@ -1,0 +1,743 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Transport-independent part of the Pelix HTTP service implementations.
+
+This module is private: it is shared by :mod:`pelix.http.basic` and
+:mod:`pelix.http.basic_async` and is not part of the public API.
+
+It holds everything that does not depend on the underlying HTTP server: the
+servlet registry, the path matching, the error pages, the logging helpers and
+the iPOPO binding logic.
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+:version: 3.2.2
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import html
+import logging
+import re
+import socket
+import threading
+import uuid
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pelix.http as http
+import pelix.ipopo.constants as constants
+import pelix.remote
+import pelix.utilities as utilities
+from pelix.internals.registry import ServiceReference
+from pelix.ipopo.decorators import HiddenProperty, Property
+
+# ------------------------------------------------------------------------------
+
+# Module version
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+# ------------------------------------------------------------------------------
+
+HTTP_SERVICE_EXTRA = "http.extra"
+""" HTTP service extra properties (dictionary) """
+
+DEFAULT_BIND_ADDRESS = "0.0.0.0"
+""" By default, bind to all IPv4 interfaces """
+
+LOCALHOST_ADDRESS = "127.0.0.1"
+"""
+Local address, if None is given as binding address, instead of the default one
+"""
+
+DEFAULT_REQUEST_QUEUE_SIZE = 5
+""" Default size of the queue of clients waiting to be handled """
+
+_MULTIPLE_SLASHES = re.compile("/+")
+""" Matches a sequence of consecutive slashes """
+
+AnyServlet = http.Servlet | http.AsyncServlet | http.WebSocketHandler
+""" Any kind of servlet service (sync, async, web socket, ...) """
+
+ServletEntry = tuple[AnyServlet, dict[str, Any], http.ServletType]
+""" Servlet registry entry: (servlet, parameters, type) """
+
+# ------------------------------------------------------------------------------
+
+
+def normalize_request_path(raw_path: str) -> str:
+    """
+    Normalizes the path of an incoming request: removes the query string and
+    collapses the sequences of consecutive slashes.
+
+    :param raw_path: The raw request path
+    :return: The path to use to look for a servlet
+    """
+    return _MULTIPLE_SLASHES.sub("/", raw_path.split("?", 1)[0])
+
+
+def compute_sub_path(full_path: str, prefix: str) -> str:
+    """
+    Computes the servlet-relative path of a request, i.e. the part of the path
+    which follows the prefix the servlet has been registered on.
+
+    :param full_path: The full request path
+    :param prefix: The path to the servlet root
+    :return: The path of the request, relative to the servlet root
+    """
+    sub_path = full_path[len(prefix) :]
+    if not sub_path.startswith("/"):
+        sub_path = f"/{sub_path}"
+
+    return _MULTIPLE_SLASHES.sub("/", sub_path)
+
+
+# ------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RequestRouting:
+    """
+    Result of the routing of an incoming request: the servlet which must handle
+    it, if any, and the normalized path it has been routed on.
+    """
+
+    path: str
+    """ The normalized request path, used both for routing and by the servlet """
+
+    servlet: Any | None
+    """ The servlet which must handle the request, or None """
+
+    parameters: dict[str, Any]
+    """ The parameters the servlet has been registered with """
+
+    prefix: str
+    """ The path the servlet has been registered on """
+
+    servlet_type: http.ServletType
+    """ The kind of servlet which must handle the request """
+
+
+# ------------------------------------------------------------------------------
+
+
+@Property("_address", http.HTTP_SERVICE_ADDRESS, DEFAULT_BIND_ADDRESS)
+@Property("_port", http.HTTP_SERVICE_PORT, 8080)
+@Property("_debug_errors", http.HTTP_DEBUG_ERRORS, False)
+@Property("_uses_ssl", http.HTTP_USES_SSL, False)
+@Property("_cert_file", http.HTTPS_CERT_FILE, None)
+@Property("_key_file", http.HTTPS_KEY_FILE, None)
+@HiddenProperty("_key_password", http.HTTPS_KEY_PASSWORD, None)
+@Property("_extra", HTTP_SERVICE_EXTRA, None)
+@Property("_instance_name", constants.IPOPO_INSTANCE_NAME)
+@Property("_logger_name", "pelix.http.logger.name", "")
+@Property("_logger_level", "pelix.http.logger.level", None)
+class AbstractHttpService(http.HTTPService):
+    """
+    Transport-independent part of the Pelix HTTP service implementations.
+    """
+
+    def __init__(self) -> None:
+        # Properties
+        self._address = DEFAULT_BIND_ADDRESS
+        self._port = 8080
+        self._debug_errors = False
+        self._uses_ssl = False
+        self._extra: dict[str, Any] | None = None
+        self._instance_name: str | None = None
+        self._logger_name: str | None = None
+        self._logger_level: str | int | None = None
+
+        # SSL Parameters
+        self._cert_file: str | None = None
+        self._key_file: str | None = None
+        self._key_password: str | None = None
+
+        # Validation flag
+        self._validated = False
+
+        # Logger (placeholder until _setup_logger is called)
+        self._logger: logging.Logger = logging.getLogger(__name__)
+
+        # Servlets registry lock
+        self._lock = threading.RLock()
+
+        # Path -> (servlet, parameters, type)
+        self._servlets: dict[str, ServletEntry] = {}
+
+        # Injected by iPOPO in the subclasses
+        self._error_handler: http.ErrorHandler | None = None
+
+        # Servlet -> ServiceReference
+        self._servlets_refs: dict[AnyServlet, ServiceReference[Any]] = {}
+        self._binding_lock = threading.RLock()
+
+    def __str__(self) -> str:
+        """
+        String representation of the instance
+        """
+        return f"BasicHttpService({self._address}, {self._port})"
+
+    # --------------------------------------------------------------------------
+    # Logging utilities
+    # --------------------------------------------------------------------------
+
+    def log(self, level: int, message: str, *args: Any, **kwargs: Any) -> None:
+        """
+        Logs the given message
+
+        :param level: Log entry level
+        :param message: Log message (Python logging format)
+        """
+        if self._logger is not None:
+            # Log the message
+            self._logger.log(level, message, *args, **kwargs)
+
+    def log_exception(self, message: str, *args: Any, **kwargs: Any) -> None:
+        """
+        Logs an exception
+
+        :param message: Log message (Python logging format)
+        """
+        if self._logger is not None:
+            # Log the exception
+            self._logger.exception(message, *args, **kwargs)
+
+    # --------------------------------------------------------------------------
+    # Configuration
+    # --------------------------------------------------------------------------
+
+    def _normalize_configuration(self) -> None:
+        """
+        Normalizes the values of the properties given to the component: binding
+        address, port and extra properties.
+        """
+        # Check if we'll use an SSL connection
+        self._uses_ssl = self._cert_file is not None
+
+        if not self._address:
+            # No address given, use the localhost address
+            self._address = LOCALHOST_ADDRESS
+
+        if self._port is None:
+            # Random port
+            self._port = 0
+        else:
+            # Ensure we have an integer
+            self._port = int(self._port)
+            # Ensure the port is positive (or set it to 0 for a random port)
+            self._port = max(self._port, 0)
+
+        # Normalize the extra properties
+        if not isinstance(self._extra, dict):
+            self._extra = {}
+
+    def _setup_logger(self) -> logging.Logger:
+        """
+        Prepares the logger of the component, according to its properties
+
+        :return: The logger to use
+        """
+        if not self._logger_name:
+            # Empty name, use the instance name
+            self._logger_name = self._instance_name
+
+        logger = logging.getLogger(self._logger_name)
+
+        level: int | None = None
+        if isinstance(self._logger_level, int):
+            level = self._logger_level
+        elif self._logger_level is not None:
+            level = utilities.get_log_level(self._logger_level)
+            if level is None:
+                try:
+                    level = int(self._logger_level)
+                except ValueError:
+                    # Invalid level
+                    level = None
+
+        logger.level = level if level is not None else logging.INFO
+        self._logger = logger
+        return logger
+
+    # --------------------------------------------------------------------------
+    # Server description
+    # --------------------------------------------------------------------------
+
+    def get_hostname(self) -> str:
+        """
+        Retrieves the server host name
+
+        :return: The server host name
+        """
+        return socket.gethostname()
+
+    def is_https(self) -> bool:
+        """
+        Returns True if this is an HTTPS server
+
+        :return: True if this server uses SSL
+        """
+        return self._uses_ssl
+
+    # --------------------------------------------------------------------------
+    # Servlets registry
+    # --------------------------------------------------------------------------
+
+    def get_registered_paths(self) -> list[str]:
+        """
+        Returns the paths registered by servlets
+
+        :return: The paths registered by servlets (sorted list)
+        """
+        return sorted(self._servlets)
+
+    def get_servlet(self, path: str | None) -> tuple[Any, dict[str, Any], str, http.ServletType] | None:
+        """
+        Retrieves the servlet matching the given path and its parameters.
+        Returns None if no servlet matches the given path.
+
+        :param path: A request URI
+        :return: A tuple (servlet, parameters, prefix, type) or None
+        """
+        if not path or path[0] != "/":
+            # No path, nothing to return
+            return None
+
+        # Use lower case for comparison
+        path = path.lower()
+
+        if path[-1] != "/":
+            # Add a trailing slash
+            path += "/"
+
+        with self._lock:
+            longest_match = ""
+            longest_match_len = 0
+            for servlet_path in self._servlets:
+                tested_path = servlet_path
+                if tested_path[-1] != "/":
+                    # Add a trailing slash
+                    tested_path += "/"
+
+                if path.startswith(tested_path) and len(servlet_path) > longest_match_len:
+                    # Found a corresponding servlet
+                    # which is deeper than the previous one
+                    longest_match = servlet_path
+                    longest_match_len = len(servlet_path)
+
+            # Return the found servlet
+            if not longest_match:
+                # No match found
+                return None
+
+            # Retrieve the stored information
+            servlet, params, servlet_type = self._servlets[longest_match]
+            return servlet, params, longest_match, servlet_type
+
+    def resolve_request(self, raw_path: str) -> "RequestRouting":
+        """
+        Finds the servlet which must handle the request on the given raw path.
+
+        :param raw_path: The raw request path, as given by the client
+        :return: The result of the routing (never None). Its ``servlet`` is
+                 None if no servlet matches the path.
+        """
+        normalized_path = normalize_request_path(raw_path)
+        found_servlet = self.get_servlet(normalized_path)
+        if found_servlet is None:
+            return RequestRouting(normalized_path, None, {}, "", http.ServletType.SYNC)
+
+        servlet, params, prefix, servlet_type = found_servlet
+        return RequestRouting(normalized_path, servlet, params, prefix, servlet_type)
+
+    def _check_servlet_type(self, servlet_type: http.ServletType) -> None:
+        """
+        Checks if the given kind of servlet is supported by this implementation.
+        Does nothing if it is supported.
+
+        :param servlet_type: The type of servlet to register
+        :raise ValueError: The kind of servlet is not supported
+        """
+        # Everything is supported by default
+
+    def register_servlet(
+        self,
+        path: str,
+        servlet: Any,
+        parameters: dict[str, Any] | None = None,
+        servlet_type: http.ServletType = http.ServletType.SYNC,
+    ) -> bool:
+        """
+        Registers a servlet
+
+        :param path: Path handled by this servlet
+        :param servlet: The servlet instance
+        :param parameters: The parameters associated to this path
+        :param servlet_type: The type of servlet (sync, async, websocket, ...)
+        :return: True if the servlet has been registered, False if it refused the binding.
+        :raise ValueError: Invalid path or handler
+        """
+        self._check_servlet_type(servlet_type)
+
+        if servlet is None:
+            raise ValueError("Invalid servlet instance")
+
+        if not path or path[0] != "/":
+            raise ValueError(f"Invalid path given to register the servlet: {path}")
+
+        # Use lower-case paths
+        path = path.lower()
+
+        # Prepare the parameters
+        if parameters is None:
+            parameters = {}
+
+        with self._lock:
+            if path in self._servlets:
+                # Already registered path
+                if self._servlets[path][0] is servlet:
+                    # Double-registration: Nothing to do
+                    return True
+                else:
+                    # Path is already taken by another servlet
+                    already_taken = True
+            else:
+                # Path is available
+                already_taken = False
+
+            # Add server information in parameters
+            parameters[http.PARAM_ADDRESS] = self._address
+            parameters[http.PARAM_PORT] = self._port
+            parameters[http.PARAM_HTTPS] = self._uses_ssl
+            parameters[http.PARAM_NAME] = self._instance_name
+            parameters[http.PARAM_EXTRA] = self._extra.copy() if self._extra else None
+            self._set_extra_parameters(parameters, servlet_type)
+
+            # The servlet might refuse to be bound to this server
+            if not self._safe_callback(servlet, "accept_binding", path, parameters):
+                # Server refused: stop right there
+                # => No need to raise the "already taken path" exception
+                return False
+
+            if already_taken:
+                # The path is already taken by another servlet
+                raise ValueError(f"A servlet is already registered on {path}")
+
+            # Tell the servlet it can be bound to the path
+            if self._safe_callback(servlet, "bound_to", path, parameters):
+                # Store the servlet
+                self._servlets[path] = (servlet, parameters, servlet_type)
+                return True
+
+            # The servlet refused the binding
+            return False
+
+    def _set_extra_parameters(self, parameters: dict[str, Any], servlet_type: http.ServletType) -> None:
+        """
+        Adds the implementation-specific entries to the parameters given to a
+        servlet when it is bound.
+
+        :param parameters: The parameters given to the servlet
+        :param servlet_type: The type of the servlet being registered
+        """
+        # Nothing to add by default
+
+    def unregister(self, path: str | None, servlet: http.Servlet | None = None) -> bool:
+        """
+        Unregisters the servlet for the given path
+
+        :param path: The path to a servlet
+        :param servlet: If given, unregisters all the paths handled by this servlet
+        :return: True if at least one path as been unregistered, else False
+        """
+        if servlet is not None:
+            with self._lock:
+                # Unregister all paths for this servlet
+                paths = [
+                    servlet_path
+                    for (servlet_path, servlet_info) in self._servlets.items()
+                    if servlet_info[0] == servlet
+                ]
+
+            result = False
+            for servlet_path in paths:
+                result |= self.unregister(servlet_path)
+
+            return result
+        else:
+            if not path:
+                # Invalid path
+                return False
+
+            # Always use lower case to compare paths
+            path = path.lower()
+
+            with self._lock:
+                # Notify the servlet
+                servlet_info = self._servlets.get(path)
+                if servlet_info is None:
+                    # Unknown path
+                    return False
+
+                self._safe_callback(servlet_info[0], "unbound_from", path, servlet_info[1])
+
+                # Remove the servlet
+                try:
+                    del self._servlets[path]
+                except KeyError:
+                    self.log(logging.DEBUG, "Tried to remove an unknown servlet path: %s", path)
+                return True
+
+    # --------------------------------------------------------------------------
+    # Error pages
+    # --------------------------------------------------------------------------
+
+    def make_not_found_page(self, path: str) -> str:
+        """
+        Prepares a "page not found" page for a 404 error
+
+        :param path: Request path
+        :return: A HTML page
+        """
+        page = None
+        if self._error_handler is not None:
+            page = self._error_handler.make_not_found_page(path)
+
+        if not page:
+            page = f"""<html>
+<head>
+<title>404 - Page not found</title>
+</head>
+<body>
+<h1>Page not found</h1>
+<p>No servlet is associated to this path:</p>
+<code>{html.escape(path)}</code>
+<h2>Registered paths:</h2>
+{http.make_html_list(self.get_registered_paths())}
+</body>
+</html>"""
+        return page
+
+    def make_exception_page(self, path: str, stack: str) -> str:
+        """
+        Prepares a page describing an error in a 500 error page.
+
+        The stack trace is only sent to the client if the
+        :const:`pelix.http.HTTP_DEBUG_ERRORS` property is set: it gives details
+        about the server and about the data it handles. It is always logged,
+        along with the error ID shown in the page.
+
+        :param path: Request path
+        :param stack: Exception stack trace
+        :return: A HTML page
+        """
+        # Log the details of the error, they are not sent to the client
+        error_id = uuid.uuid4().hex
+        (self._logger or logging.getLogger(__name__)).error(
+            "Error %s handling request upon: %s\n%s", error_id, path, stack
+        )
+
+        # Only tell the client how to find the error in the logs
+        details = stack if self._debug_errors else f"Error ID: {error_id}"
+
+        page = None
+        if self._error_handler is not None:
+            page = self._error_handler.make_exception_page(path, details)
+
+        if not page:
+            page = f"""<html>
+<head>
+<title>500 - Internal Server Error</title>
+</head>
+<body>
+<h1>Internal Server Error</h1>
+<p>Error handling request upon: <code>{html.escape(path)}</code></p>
+<pre>
+{html.escape(details)}
+</pre>
+</body>
+</html>"""
+        return page
+
+    # --------------------------------------------------------------------------
+    # iPOPO bindings
+    # --------------------------------------------------------------------------
+
+    def _safe_callback(self, instance: Any, method: str, *args: Any, **kwargs: Any) -> Any:
+        """
+        Safely calls the given method in the given instance.
+        Returns True on method absence.
+        Returns False on error.
+        Returns the method result if found.
+
+        :param instance: The instance to call
+        :param method: The method to call in the instance
+        :return: The method result or True on method absence or False on error
+        """
+        # Call back the method
+        if instance is None:
+            # Consider invalidity as a failure
+            return False
+
+        try:
+            callback = getattr(instance, method)
+        except AttributeError:
+            # Consider absence as a success
+            return True
+
+        try:
+            result = callback(*args, **kwargs)
+            if result is None:
+                # Special case: consider None as success
+                return True
+
+            return result
+        except Exception as ex:
+            self.log_exception("Error calling back an instance: %s", ex)
+
+        return False
+
+    def _register_servlet_service(
+        self, service: AnyServlet, service_reference: ServiceReference[Any]
+    ) -> None:
+        """
+        Registers a servlet according to its service properties.
+        Implemented by the subclasses, as they do not support the same kinds of
+        servlet.
+
+        :param service: A servlet service
+        :param service_reference: The associated ServiceReference
+        """
+        raise NotImplementedError
+
+    def _on_bind(self, service: AnyServlet, service_reference: ServiceReference[Any]) -> None:
+        """
+        A servlet service has been bound
+
+        :param service: A servlet service
+        :param service_reference: The associated ServiceReference
+        """
+        # Ignore imported services
+        if self._is_imported(service_reference):
+            self.log(logging.DEBUG, "Ignoring service as it is imported: %s", service_reference)
+            return
+
+        with self._binding_lock:
+            self._servlets_refs[service] = service_reference
+
+            if self._validated:
+                # We've been validated, register the service
+                self._register_servlet_service(service, service_reference)
+
+    def _on_update(
+        self,
+        service: AnyServlet,
+        service_reference: ServiceReference[Any],
+        old_properties: dict[str, Any],
+        watched_properties: tuple[str, ...],
+    ) -> None:
+        """
+        The properties of a servlet service have been updated
+
+        :param service: A servlet service
+        :param service_reference: The associated ServiceReference
+        :param old_properties: The previous properties of the service
+        :param watched_properties: Names of the properties which, when modified,
+                                   require the servlet to be registered again
+        """
+        # Ignore imported services
+        if self._is_imported(service_reference):
+            return
+
+        # Check if the update concerns the registration
+        if all(
+            old_properties.get(name) == service_reference.get_property(name) for name in watched_properties
+        ):
+            # Nothing to do
+            return
+
+        with self._binding_lock:
+            # Unregister the previous paths
+            self.unregister(None, cast(http.Servlet, service))
+
+            if self._validated:
+                # Register the service with its new properties
+                self._register_servlet_service(service, service_reference)
+
+    def _on_unbind(self, service: AnyServlet, service_reference: ServiceReference[Any]) -> None:
+        """
+        A servlet service is gone
+
+        :param service: A servlet service
+        :param service_reference: The associated ServiceReference
+        """
+        # Ignore imported services
+        if self._is_imported(service_reference):
+            return
+
+        with self._binding_lock:
+            # Servlet gone: unregister all paths associated to this servlet
+            self.unregister(None, cast(http.Servlet, service))
+
+            # Remove the service reference
+            try:
+                del self._servlets_refs[service]
+            except KeyError:
+                self.log(logging.DEBUG, "Tried to remove an unknown servlet: %s", service)
+
+    def _register_bound_servlets(self) -> None:
+        """
+        Registers the servlets which have been bound before the component was
+        validated. Must be called once the server is ready.
+        """
+        with self._binding_lock:
+            # Set the validation flag up, once the server is ready
+            self._validated = True
+
+            # Register bound servlets
+            for service, svc_ref in self._servlets_refs.items():
+                self._register_servlet_service(service, svc_ref)
+
+    def _unregister_all_servlets(self) -> None:
+        """
+        Refuses new registrations and unregisters all the bound servlets, to
+        notify them with ``unbound_from``.
+        """
+        with self._binding_lock:
+            # Refuse new registrations
+            self._validated = False
+
+            # Unregister servlets (to call unbound_from...)
+            for service in self._servlets_refs:
+                self.unregister(None, cast(http.Servlet, service))
+
+    @staticmethod
+    def _is_imported(service_reference: ServiceReference[Any]) -> bool:
+        """
+        Tests if the given service has been imported by Remote Services
+
+        :param service_reference: The reference of the service to check
+        :return: True if the service is flagged as imported
+        """
+        return cast(bool, service_reference.get_property(pelix.remote.PROP_IMPORTED))

--- a/pelix/http/basic.py
+++ b/pelix/http/basic.py
@@ -36,10 +36,8 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import TCPServer, ThreadingMixIn
 from typing import IO, TYPE_CHECKING, Any, cast
 
-import pelix.http as http
 import pelix.ipv6utils
-import pelix.misc.ssl_wrap as ssl_wrap
-import pelix.utilities as utilities
+from pelix import http, utilities
 from pelix.http._base import (
     DEFAULT_BIND_ADDRESS,
     DEFAULT_REQUEST_QUEUE_SIZE,
@@ -59,6 +57,7 @@ from pelix.ipopo.decorators import (
     UpdateField,
     Validate,
 )
+from pelix.misc import ssl_wrap
 
 if TYPE_CHECKING:
     from pelix.framework import BundleContext

--- a/pelix/http/basic.py
+++ b/pelix/http/basic.py
@@ -28,40 +28,31 @@ Python library.
     limitations under the License.
 """
 
-import html
 import logging
 import socket
 import threading
 import traceback
-import uuid
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import TCPServer, ThreadingMixIn
-from typing import (
-    IO,
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import IO, TYPE_CHECKING, Any, cast
 
 import pelix.http as http
-import pelix.ipopo.constants as constants
 import pelix.ipv6utils
 import pelix.misc.ssl_wrap as ssl_wrap
-import pelix.remote
 import pelix.utilities as utilities
+from pelix.http._base import (
+    DEFAULT_BIND_ADDRESS,
+    DEFAULT_REQUEST_QUEUE_SIZE,
+    HTTP_SERVICE_EXTRA,
+    LOCALHOST_ADDRESS,
+    AbstractHttpService,
+    compute_sub_path,
+)
 from pelix.internals.registry import ServiceReference
 from pelix.ipopo.decorators import (
     BindField,
     ComponentFactory,
-    HiddenProperty,
     Invalidate,
-    Property,
     Provides,
     Requires,
     UnbindField,
@@ -83,16 +74,8 @@ __docformat__ = "restructuredtext en"
 
 # ------------------------------------------------------------------------------
 
-HTTP_SERVICE_EXTRA = "http.extra"
-""" HTTP service extra properties (dictionary) """
-
-DEFAULT_BIND_ADDRESS = "0.0.0.0"
-""" By default, bind to all IPv4 interfaces """
-
-LOCALHOST_ADDRESS = "127.0.0.1"
-"""
-Local address, if None is given as binding address, instead of the default one
-"""
+# Kept for backward compatibility: those constants are now defined in _base
+__all__ = ["DEFAULT_BIND_ADDRESS", "HTTP_SERVICE_EXTRA", "LOCALHOST_ADDRESS", "HttpServiceImpl"]
 
 # ------------------------------------------------------------------------------
 
@@ -102,23 +85,19 @@ class _HTTPServletRequest(http.AbstractHTTPServletRequest):
     HTTP Servlet request helper
     """
 
-    def __init__(self, request_handler: BaseHTTPRequestHandler, prefix: str) -> None:
+    def __init__(self, request_handler: BaseHTTPRequestHandler, full_path: str, prefix: str) -> None:
         """
         Sets up the request helper
 
         :param request_handler: The basic request handler
+        :param full_path: The normalized request path, including the prefix
         :param prefix: The path to the servlet root
         """
         self._handler = request_handler
         self._prefix = prefix
 
         # Compute the sub path
-        self._sub_path = self._handler.path[len(prefix) :]
-        if not self._sub_path.startswith("/"):
-            self._sub_path = "/{0}".format(self._sub_path)
-
-        while "//" in self._sub_path:
-            self._sub_path = self._sub_path.replace("//", "/")
+        self._sub_path = compute_sub_path(full_path, prefix)
 
     def get_command(self) -> str:
         """
@@ -126,7 +105,7 @@ class _HTTPServletRequest(http.AbstractHTTPServletRequest):
         """
         return self._handler.command
 
-    def get_client_address(self) -> Tuple[str, int]:
+    def get_client_address(self) -> tuple[str, int]:
         """
         Retrieves the address of the client
 
@@ -134,17 +113,17 @@ class _HTTPServletRequest(http.AbstractHTTPServletRequest):
         """
         return self._handler.client_address
 
-    def get_header(self, name: str, default: Optional[Any] = None) -> Any:
+    def get_header(self, name: str, default: Any | None = None) -> Any:
         """
         Retrieves the value of a header
         """
         return self._handler.headers.get(name, default)
 
-    def get_headers(self) -> Dict[str, Any]:
+    def get_headers(self) -> dict[str, Any]:
         """
         Retrieves all headers
         """
-        return cast(Dict[str, Any], self._handler.headers)
+        return cast(dict[str, Any], self._handler.headers)
 
     def get_path(self) -> str:
         """
@@ -187,9 +166,9 @@ class _HTTPServletResponse(http.AbstractHTTPServletResponse):
         :param request_handler: The basic request handler
         """
         self._handler = request_handler
-        self._headers: Dict[str, Any] = {}
+        self._headers: dict[str, Any] = {}
 
-    def set_response(self, code: int, message: Optional[str] = None) -> None:
+    def set_response(self, code: int, message: str | None = None) -> None:
         """
         Sets the response line.
         This method should be the first called when sending an answer.
@@ -260,7 +239,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
     # Override the default HTTP version
     default_request_version = "HTTP/1.0"
 
-    def __init__(self, http_svc: http.HTTPService, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, http_svc: AbstractHttpService, *args: Any, **kwargs: Any) -> None:
         """
         Sets up the request handler (called for each request)
 
@@ -284,32 +263,28 @@ class _RequestHandler(BaseHTTPRequestHandler):
             # Not a request handling
             return object.__getattribute__(self, name)
 
-        # Remove the query part and double-slashes in the request path
-        parsed_path = self.path.split("?", 1)[0].replace("//", "/")
-
         # Get the corresponding servlet
-        found_servlet = self._service.get_servlet(parsed_path)
-        if found_servlet is not None:
-            servlet, _, prefix, _ = found_servlet
-            if hasattr(servlet, name):
-                # Prepare the helpers
-                request = _HTTPServletRequest(self, prefix)
-                response = _HTTPServletResponse(self)
+        routing = self._service.resolve_request(self.path)
+        servlet = routing.servlet
+        if servlet is not None and hasattr(servlet, name):
+            # Prepare the helpers
+            request = _HTTPServletRequest(self, routing.path, routing.prefix)
+            response = _HTTPServletResponse(self)
 
-                # Create a wrapper to pass the handler to the servlet
-                def wrapper() -> None:
-                    """
-                    Wrapped servlet call
-                    """
-                    try:
-                        # Handle the request
-                        getattr(servlet, name)(request, response)
-                    except Exception:
-                        # Send a 500 error page on error
-                        self.send_exception(response)
+            # Create a wrapper to pass the handler to the servlet
+            def wrapper() -> None:
+                """
+                Wrapped servlet call
+                """
+                try:
+                    # Handle the request
+                    getattr(servlet, name)(request, response)
+                except Exception:
+                    # Send a 500 error page on error
+                    self.send_exception(response)
 
-                # Return it
-                return wrapper
+            # Return it
+            return wrapper
 
         # Return the super implementation if needed
         return self.send_no_servlet_response
@@ -321,7 +296,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
         """
         self._service.log(logging.ERROR, format, *args, **kwargs)
 
-    def log_request(self, code: Union[str, int] = "-", size: Union[str, int] = "-") -> None:
+    def log_request(self, code: str | int = "-", size: str | int = "-") -> None:
         """
         Logs a request to the server
         """
@@ -365,10 +340,10 @@ class _HttpServerFamily(ThreadingMixIn, HTTPServer):
 
     def __init__(
         self,
-        server_address: Tuple[str, int],
-        request_handler_class: Type[BaseHTTPRequestHandler],
+        server_address: tuple[str, int],
+        request_handler_class: type[BaseHTTPRequestHandler],
         request_queue_size: int = 5,
-        logger: Optional[logging.Logger] = None,
+        logger: logging.Logger | None = None,
     ):
         """
         Proxy constructor
@@ -397,12 +372,12 @@ class _HttpServerFamily(ThreadingMixIn, HTTPServer):
             # Explicitly ask to be accessible both by IPv4 and IPv6
             try:
                 pelix.ipv6utils.set_double_stack(self.socket)
-            except AttributeError as ex:
+            except AttributeError:
                 if logger is not None:
-                    logger.exception("System misses IPv6 constant: %s", ex)
-            except socket.error as ex:
+                    logger.exception("System misses IPv6 constant")
+            except OSError:
                 if logger is not None:
-                    logger.exception("Error setting up IPv6 double stack: %s", ex)
+                    logger.exception("Error setting up IPv6 double stack")
 
         # Bind & accept
         self.server_bind()
@@ -424,7 +399,7 @@ class _HttpServerFamily(ThreadingMixIn, HTTPServer):
             self.server_name = socket.gethostname()
 
     def process_request(
-        self, request: socket.socket | Tuple[bytes, socket.socket], client_address: Any
+        self, request: socket.socket | tuple[bytes, socket.socket], client_address: Any
     ) -> None:
         """
         Starts a new thread to process the request, adding the client address
@@ -446,107 +421,36 @@ class _HttpServerFamily(ThreadingMixIn, HTTPServer):
 @Provides(http.HTTP_SERVICE)
 @Requires("_servlets_services", http.Servlet, True, True)
 @Requires("_error_handler", http.ErrorHandler, optional=True)
-@Property("_address", http.HTTP_SERVICE_ADDRESS, DEFAULT_BIND_ADDRESS)
-@Property("_port", http.HTTP_SERVICE_PORT, 8080)
-@Property("_uses_ssl", http.HTTP_USES_SSL, False)
-@Property("_cert_file", http.HTTPS_CERT_FILE, None)
-@Property("_key_file", http.HTTPS_KEY_FILE, None)
-@HiddenProperty("_key_password", http.HTTPS_KEY_PASSWORD, None)
-@Property("_extra", HTTP_SERVICE_EXTRA, None)
-@Property("_instance_name", constants.IPOPO_INSTANCE_NAME)
-@Property("_logger_name", "pelix.http.logger.name", "")
-@Property("_logger_level", "pelix.http.logger.level", None)
-@Property("_request_queue_size", "pelix.http.request_queue_size", 100)
-@Property("_debug_errors", http.HTTP_DEBUG_ERRORS, False)
-class HttpServiceImpl(http.HTTPService):
+class HttpServiceImpl(AbstractHttpService):
     """
     Basic HTTP service component
     """
 
     def __init__(self) -> None:
-        # Properties
-        self._address = "0.0.0.0"
-        self._port = 8080
-        self._uses_ssl = False
-        self._debug_errors = False
-        self._extra: Optional[Dict[str, Any]] = None
-        self._instance_name: Optional[str] = None
-        self._logger_name: Optional[str] = None
-        self._logger_level: Optional[int] = None
-        self._request_queue_size = 5
+        super().__init__()
 
-        # SSL Parameters
-        self._cert_file: Optional[str] = None
-        self._key_file: Optional[str] = None
-        self._key_password: Optional[str] = None
+        # Property specific to this implementation
+        self._request_queue_size = DEFAULT_REQUEST_QUEUE_SIZE
 
-        # Validation flag
-        self._validated = False
-
-        # The logger
-        self._logger: Optional[logging.Logger] = None
-
-        # Servlets registry lock
-        self._lock = threading.RLock()
-
-        # Path -> (servlet, parameters)
-        self._servlets: Dict[str, Tuple[http.Servlet, Dict[str, Any]]] = {}
-
-        # Fields injected by iPOPO
-        self._servlets_services: List[http.Servlet] = []
-        self._error_handler: Optional[http.ErrorHandler] = None
-
-        # Servlet -> ServiceReference
-        self._servlets_refs: Dict[http.Servlet, ServiceReference[http.Servlet]] = {}
-        self._binding_lock = threading.RLock()
+        # Field injected by iPOPO
+        self._servlets_services: list[http.Servlet] = []
 
         # Server control
-        self._server: Optional[HTTPServer] = None
-        self._thread: Optional[threading.Thread] = None
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
 
-    def __str__(self) -> str:
+    def _check_servlet_type(self, servlet_type: http.ServletType) -> None:
         """
-        String representation of the instance
+        This implementation only supports synchronous servlets
+
+        :param servlet_type: The type of servlet to register
+        :raise ValueError: The kind of servlet is not supported
         """
-        return f"BasicHttpService({self._address}, {self._port})"
+        if servlet_type != http.ServletType.SYNC:
+            raise ValueError("Asynchronous mode is not supported")
 
-    def __safe_callback(self, instance: http.Servlet, method: str, *args: Any, **kwargs: Any) -> Any:
-        """
-        Safely calls the given method in the given instance.
-        Returns True on method absence.
-        Returns False on error.
-        Returns the method result if found.
-
-        :param instance: The instance to call
-        :param method: The method to call in the instance
-        :return: The method result or True on method absence or False on error
-        """
-        # Call back the method
-        if instance is None:
-            # Consider invalidity as a failure
-            return False
-
-        try:
-            callback = getattr(instance, method)
-        except AttributeError:
-            # Consider absence as a success
-            return True
-
-        try:
-            result = callback(*args, **kwargs)
-            if result is None:
-                # Special case: consider None as success
-                return True
-
-            return result
-
-        except Exception as ex:
-            self.log_exception("Error calling back an instance: %s", ex)
-
-        return False
-
-    def __register_servlet_service(
-        self, service: http.Servlet, service_reference: ServiceReference[http.Servlet]
+    def _register_servlet_service(
+        self, service: http.Servlet, service_reference: ServiceReference[Any]
     ) -> None:
         """
         Registers a servlet according to its service properties
@@ -569,15 +473,7 @@ class HttpServiceImpl(http.HTTPService):
         """
         Called by iPOPO when a service is bound
         """
-        # Ignore imported services
-        if self.__is_imported(service_reference):
-            return
-        with self._binding_lock:
-            self._servlets_refs[service] = service_reference
-
-            if self._validated:
-                # We've been validated, register the service
-                self.__register_servlet_service(service, service_reference)
+        self._on_bind(service, service_reference)
 
     @UpdateField("_servlets_services")
     def _update(
@@ -585,28 +481,12 @@ class HttpServiceImpl(http.HTTPService):
         _: str,
         service: http.Servlet,
         service_reference: ServiceReference[http.Servlet],
-        old_properties: Dict[str, Any],
+        old_properties: dict[str, Any],
     ) -> None:
         """
         Called by iPOPO when the properties of a service have been updated
         """
-        # Ignore imported services
-        if self.__is_imported(service_reference):
-            return
-        # Check if the property concerns the registration
-        old_path = old_properties.get(http.HTTP_SERVLET_PATH)
-        new_path = service_reference.get_property(http.HTTP_SERVLET_PATH)
-        if old_path == new_path:
-            # Nothing to do
-            return
-
-        with self._binding_lock:
-            # Unregister the previous paths
-            self.unregister(None, service)
-
-            if self._validated:
-                # Register the service with its new properties
-                self.__register_servlet_service(service, service_reference)
+        self._on_update(service, service_reference, old_properties, (http.HTTP_SERVLET_PATH,))
 
     @UnbindField("_servlets_services")
     def _unbind(
@@ -615,20 +495,9 @@ class HttpServiceImpl(http.HTTPService):
         """
         Called by iPOPO when a service is gone
         """
-        # Ignore imported services
-        if self.__is_imported(service_reference):
-            return
-        with self._binding_lock:
-            # Servlet gone: unregister all paths associated to this servlet
-            self.unregister(None, service)
+        self._on_unbind(service, service_reference)
 
-            # Remove the service reference
-            try:
-                del self._servlets_refs[service]
-            except KeyError:
-                self.log(logging.DEBUG, "Tried to remove an unknown servlet: %s", service)
-
-    def get_access(self) -> Tuple[str, int]:
+    def get_access(self) -> tuple[str, int]:
         """
         Retrieves the (address, port) tuple to access the server
         """
@@ -638,339 +507,22 @@ class HttpServiceImpl(http.HTTPService):
         # Only keep the address and the port information
         return sock_info[0], sock_info[1]
 
-    @staticmethod
-    def get_hostname() -> str:
-        """
-        Retrieves the server host name
-
-        :return: The server host name
-        """
-        return socket.gethostname()
-
-    def is_https(self) -> bool:
-        """
-        Returns True if this is an HTTPS server
-
-        :return: True if this server uses SSL
-        """
-        return self._uses_ssl
-
-    def get_registered_paths(self) -> List[str]:
-        """
-        Returns the paths registered by servlets
-
-        :return: The paths registered by servlets (sorted list)
-        """
-        return sorted(self._servlets)
-
-    def get_servlet(
-        self, path: Optional[str]
-    ) -> Optional[Tuple[http.Servlet, Dict[str, Any], str, http.ServletType]]:
-        """
-        Retrieves the servlet matching the given path and its parameters.
-        Returns None if no servlet matches the given path.
-
-        :param path: A request URI
-        :return: A tuple (servlet, parameters, prefix) or None
-        """
-        if not path or path[0] != "/":
-            # No path, nothing to return
-            return None
-
-        # Use lower case for comparison
-        path = path.lower()
-
-        if path[-1] != "/":
-            # Add a trailing slash
-            path += "/"
-
-        with self._lock:
-            longest_match = ""
-            longest_match_len = 0
-            for servlet_path in self._servlets:
-                tested_path = servlet_path
-                if tested_path[-1] != "/":
-                    # Add a trailing slash
-                    tested_path += "/"
-
-                if path.startswith(tested_path) and len(servlet_path) > longest_match_len:
-                    # Found a corresponding servlet
-                    # which is deeper than the previous one
-                    longest_match = servlet_path
-                    longest_match_len = len(servlet_path)
-
-            # Return the found servlet
-            if not longest_match:
-                # No match found
-                return None
-
-            # Retrieve the stored information
-            servlet, params = self._servlets[longest_match]
-            return servlet, params, longest_match, http.ServletType.SYNC
-
-    def make_not_found_page(self, path: str) -> str:
-        """
-        Prepares a "page not found" page for a 404 error
-
-        :param path: Request path
-        :return: A HTML page
-        """
-        page = None
-        if self._error_handler is not None:
-            page = self._error_handler.make_not_found_page(path)
-
-        if not page:
-            page = f"""<html>
-<head>
-<title>404 - Page not found</title>
-</head>
-<body>
-<h1>Page not found</h1>
-<p>No servlet is associated to this path:</p>
-<code>{html.escape(path)}</code>
-<h2>Registered paths:</h2>
-{http.make_html_list(self.get_registered_paths())}
-</body>
-</html>"""
-        return page
-
-    def make_exception_page(self, path: str, stack: str) -> str:
-        """
-        Prepares a page describing an error in a 500 error page.
-
-        The stack trace is only sent to the client if the
-        :const:`pelix.http.HTTP_DEBUG_ERRORS` property is set: it gives details
-        about the server and about the data it handles. It is always logged,
-        along with the error ID shown in the page.
-
-        :param path: Request path
-        :param stack: Exception stack trace
-        :return: A HTML page
-        """
-        # Log the details of the error, they are not sent to the client
-        error_id = uuid.uuid4().hex
-        (self._logger or logging.getLogger(__name__)).error(
-            "Error %s handling request upon: %s\n%s", error_id, path, stack
-        )
-
-        # Only tell the client how to find the error in the logs
-        details = stack if self._debug_errors else f"Error ID: {error_id}"
-
-        page = None
-        if self._error_handler is not None:
-            page = self._error_handler.make_exception_page(path, details)
-
-        if not page:
-            page = f"""<html>
-<head>
-<title>500 - Internal Server Error</title>
-</head>
-<body>
-<h1>Internal Server Error</h1>
-<p>Error handling request upon: <code>{html.escape(path)}</code></p>
-<pre>
-{html.escape(details)}
-</pre>
-</body>
-</html>"""
-        return page
-
-    def register_servlet(
-        self,
-        path: str,
-        servlet: http.Servlet,
-        parameters: Optional[Dict[str, Any]] = None,
-        servlet_type: http.ServletType = http.ServletType.SYNC,
-    ) -> bool:
-        """
-        Registers a servlet
-
-        :param path: Path handled by this servlet
-        :param servlet: The servlet instance
-        :param parameters: The parameters associated to this path
-        :param servlet_type: The type of servlet (sync, async, websocket, ...)
-        :return: True if the servlet has been registered, False if it refused the binding.
-        :raise ValueError: Invalid path or handler
-        """
-        if servlet_type != http.ServletType.SYNC:
-            raise ValueError("Asynchronous mode is not supported")
-
-        if servlet is None:
-            raise ValueError("Invalid servlet instance")
-
-        if not path or path[0] != "/":
-            raise ValueError("Invalid path given to register the servlet: {0}".format(path))
-
-        # Use lower-case paths
-        path = path.lower()
-
-        # Prepare the parameters
-        if parameters is None:
-            parameters = {}
-
-        with self._lock:
-            if path in self._servlets:
-                # Already registered path
-                if self._servlets[path][0] is servlet:
-                    # Double-registration: Nothing to do
-                    return True
-                else:
-                    # Path is already taken by another servlet
-                    already_taken = True
-            else:
-                # Path is available
-                already_taken = False
-
-            # Add server information in parameters
-            parameters[http.PARAM_ADDRESS] = self._address
-            parameters[http.PARAM_PORT] = self._port
-            parameters[http.PARAM_HTTPS] = self._uses_ssl
-            parameters[http.PARAM_NAME] = self._instance_name
-            parameters[http.PARAM_EXTRA] = self._extra.copy() if self._extra else None
-
-            # The servlet might refuse to be bound to this server
-            if not self.__safe_callback(servlet, "accept_binding", path, parameters):
-                # Server refused: stop right there
-                # => No need to raise the "already taken path" exception
-                return False
-
-            if already_taken:
-                # The path is already taken by another servlet
-                raise ValueError("A servlet is already registered on {0}".format(path))
-
-            # Tell the servlet it can be bound to the path
-            if self.__safe_callback(servlet, "bound_to", path, parameters):
-                # Store the servlet
-                self._servlets[path] = (servlet, parameters)
-                return True
-
-            # The servlet refused the binding
-            return False
-
-    def unregister(self, path: Optional[str], servlet: Optional[http.Servlet] = None) -> bool:
-        """
-        Unregisters the servlet for the given path
-
-        :param path: The path to a servlet
-        :param servlet: If given, unregisters all the paths handled by this servlet
-        :return: True if at least one path as been unregistered, else False
-        """
-        if servlet is not None:
-            with self._lock:
-                # Unregister all paths for this servlet
-                paths = [
-                    servlet_path
-                    for (servlet_path, servlet_info) in self._servlets.items()
-                    if servlet_info[0] == servlet
-                ]
-
-            result = False
-            for servlet_path in paths:
-                result |= self.unregister(servlet_path)
-
-            return result
-        else:
-            if not path:
-                # Invalid path
-                return False
-
-            # Always use lower case to compare paths
-            path = path.lower()
-
-            with self._lock:
-                # Notify the servlet
-                servlet_info = self._servlets.get(path)
-                if servlet_info is None:
-                    # Unknown path
-                    return False
-
-                self.__safe_callback(servlet_info[0], "unbound_from", path, servlet_info[1])
-
-                # Remove the servlet
-                try:
-                    del self._servlets[path]
-                except KeyError:
-                    self.log(logging.DEBUG, "Tried to remove an unknown servlet path: %s", path)
-                return True
-
-    def log(self, level: int, message: str, *args: Any, **kwargs: Any) -> None:
-        """
-        Logs the given message
-
-        :param level: Log entry level
-        :param message: Log message (Python logging format)
-        """
-        if self._logger is not None:
-            # Log the message
-            self._logger.log(level, message, *args, **kwargs)
-
-    def log_exception(self, message: str, *args: Any, **kwargs: Any) -> None:
-        """
-        Logs an exception
-
-        :param message: Log message (Python logging format)
-        """
-        if self._logger is not None:
-            # Log the exception
-            self._logger.exception(message, *args, **kwargs)
-
     @Validate
     def validate(self, _: "BundleContext") -> None:
         """
         Component validation
         """
-        # Check if we'll use an SSL connection
-        self._uses_ssl = self._cert_file is not None
-
-        if not self._address:
-            # No address given, use the localhost address
-            self._address = LOCALHOST_ADDRESS
-
-        if self._port is None:
-            # Random port
-            self._port = 0
-        else:
-            # Ensure we have an integer
-            self._port = int(self._port)
-            if self._port < 0:
-                # Random port
-                self._port = 0
+        self._normalize_configuration()
+        self._setup_logger()
 
         # Normalize the request queue size
         try:
             self._request_queue_size = int(self._request_queue_size)
         except (ValueError, TypeError):
-            self._request_queue_size = 5
+            self._request_queue_size = DEFAULT_REQUEST_QUEUE_SIZE
 
         if self._request_queue_size <= 0:
-            self._request_queue_size = 5
-
-        # Normalize the extra properties
-        if not isinstance(self._extra, dict):
-            self._extra = {}
-
-        # Set up the logger
-        if not self._logger_name:
-            # Empty name, use the instance name
-            self._logger_name = self._instance_name
-
-        self._logger = logging.getLogger(self._logger_name)
-
-        level: int | None = None
-        if self._logger_level is None:
-            self._logger.level = logging.INFO
-        elif isinstance(self._logger_level, int):
-            level = self._logger_level
-        else:
-            level = utilities.get_log_level(self._logger_level)
-            if level is None:
-                try:
-                    level = int(self._logger_level)
-                except ValueError:
-                    # Invalid level
-                    level = None
-
-        self._logger.level = level if level is not None else logging.INFO
+            self._request_queue_size = DEFAULT_REQUEST_QUEUE_SIZE
 
         self.log(
             logging.INFO,
@@ -1017,13 +569,8 @@ class HttpServiceImpl(http.HTTPService):
         self._thread.daemon = True
         self._thread.start()
 
-        with self._binding_lock:
-            # Set the validation flag up, once the server is ready
-            self._validated = True
-
-            # Register bound servlets
-            for service, svc_ref in self._servlets_refs.items():
-                self.__register_servlet_service(service, svc_ref)
+        # Register the servlets bound before the server was ready
+        self._register_bound_servlets()
 
         self.log(
             logging.INFO,
@@ -1038,13 +585,8 @@ class HttpServiceImpl(http.HTTPService):
         """
         Component invalidation
         """
-        with self._binding_lock:
-            # Refuse new registrations
-            self._validated = False
-
-            # Unregister servlets (to call unbound_from...)
-            for service in self._servlets_refs:
-                self.unregister(None, service)
+        # Refuse new registrations and notify the bound servlets
+        self._unregister_all_servlets()
 
         self.log(
             logging.INFO,
@@ -1082,14 +624,5 @@ class HttpServiceImpl(http.HTTPService):
         self._servlets.clear()
         self._thread = None
         self._server = None
-        self._logger = None
-
-    @staticmethod
-    def __is_imported(service_reference: ServiceReference[Any]) -> bool:
-        """
-        Tests if the given service has been imported by Remote Services
-
-        :param service_reference: The reference of the service to check
-        :return: True if the service is flagged as imported
-        """
-        return cast(bool, service_reference.get_property(pelix.remote.PROP_IMPORTED))
+        # Rename the logger, to detect late use after invalidation
+        self._logger = logging.getLogger(f"{self._logger.name}--invalidated")

--- a/pelix/http/basic_async.py
+++ b/pelix/http/basic_async.py
@@ -29,33 +29,32 @@ Provides an implementation of the Pelix HTTP service based on aiohttp.
 
 import asyncio
 import concurrent.futures
-import html
 import io
 import logging
-import re
-import socket
 import ssl
 import sys
 import threading
 import traceback
-import uuid
-from typing import IO, TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
+from typing import IO, TYPE_CHECKING, Any, cast
 
 import aiohttp.client_exceptions
 import aiohttp.web
 
 import pelix.constants as fw_constants
 import pelix.http as http
-import pelix.ipopo.constants as constants
-import pelix.remote
 import pelix.utilities as utilities
+from pelix.http._base import (
+    DEFAULT_BIND_ADDRESS,
+    HTTP_SERVICE_EXTRA,
+    LOCALHOST_ADDRESS,
+    AbstractHttpService,
+    compute_sub_path,
+)
 from pelix.internals.registry import ServiceReference
 from pelix.ipopo.decorators import (
     BindField,
     ComponentFactory,
-    HiddenProperty,
     Invalidate,
-    Property,
     Provides,
     Requires,
     UnbindField,
@@ -78,16 +77,14 @@ __docformat__ = "restructuredtext en"
 
 # ------------------------------------------------------------------------------
 
-HTTP_SERVICE_EXTRA = "http.extra"
-""" HTTP service extra properties (dictionary) """
-
-DEFAULT_BIND_ADDRESS = "0.0.0.0"
-""" By default, bind to all IPv4 interfaces """
-
-LOCALHOST_ADDRESS = "127.0.0.1"
-"""
-Local address, if None is given as binding address, instead of the default one
-"""
+# Kept for backward compatibility: those constants are now defined in _base
+__all__ = [
+    "DEFAULT_BIND_ADDRESS",
+    "HTTP_SERVICE_EXTRA",
+    "LOCALHOST_ADDRESS",
+    "AsyncHttpServiceImpl",
+    "WSSession",
+]
 
 
 class _SyncHTTPServletRequest(http.AbstractHTTPServletRequest):
@@ -109,11 +106,7 @@ class _SyncHTTPServletRequest(http.AbstractHTTPServletRequest):
         self._content = content
 
         # Compute the sub path
-        self._sub_path = full_path[len(prefix) :]
-        if not self._sub_path.startswith("/"):
-            self._sub_path = f"/{self._sub_path}"
-
-        self._sub_path = re.sub("/+", "/", self._sub_path)
+        self._sub_path = compute_sub_path(full_path, prefix)
 
     def get_command(self) -> str:
         """
@@ -121,7 +114,7 @@ class _SyncHTTPServletRequest(http.AbstractHTTPServletRequest):
         """
         return self._request.method.upper()
 
-    def get_client_address(self) -> Tuple[str, int]:
+    def get_client_address(self) -> tuple[str, int]:
         """
         Retrieves the address of the client
 
@@ -129,24 +122,24 @@ class _SyncHTTPServletRequest(http.AbstractHTTPServletRequest):
         """
         if self._request.transport is None:
             # No transport, no address
-            raise IOError("No transport available for the request")
+            raise OSError("No transport available for the request")
 
         peer_name = self._request.transport.get_extra_info("peername")
         if not peer_name:
-            raise IOError("No peer name available for the request")
+            raise OSError("No peer name available for the request")
         return peer_name[:2]
 
-    def get_header(self, name: str, default: Optional[Any] = None) -> Any:
+    def get_header(self, name: str, default: Any | None = None) -> Any:
         """
         Retrieves the value of a header
         """
         return self._request.headers.get(name, default)
 
-    def get_headers(self) -> Dict[str, Any]:
+    def get_headers(self) -> dict[str, Any]:
         """
         Retrieves all headers
         """
-        return cast(Dict[str, Any], self._request.headers)
+        return cast(dict[str, Any], self._request.headers)
 
     def get_path(self) -> str:
         """
@@ -192,16 +185,16 @@ class _WriteWrapper(IO[bytes]):
         return self._buffer.getvalue()
 
     def read(self, size: int = -1) -> bytes:
-        raise IOError("This stream is not readable")
+        raise OSError("This stream is not readable")
 
     def write(self, b: bytes) -> int:
         return self._buffer.write(b)
 
     def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
-        raise IOError("This stream is not seekable")
+        raise OSError("This stream is not seekable")
 
     def tell(self) -> int:
-        raise IOError("This stream is not seekable")
+        raise OSError("This stream is not seekable")
 
     def close(self) -> None:
         self._closed = True
@@ -237,7 +230,7 @@ class _SyncHTTPServletResponse(http.AbstractHTTPServletResponse):
         """
         self._request = request
         self._loop = loop
-        self._headers: Dict[str, str] = {}
+        self._headers: dict[str, str] = {}
         self._headers_set: bool = False
         self._code: int = 200
         self._message: str | None = None
@@ -254,7 +247,7 @@ class _SyncHTTPServletResponse(http.AbstractHTTPServletResponse):
             body=self._writer.get(), status=self._code, reason=self._message, headers=self._headers
         )
 
-    def set_response(self, code: int, message: Optional[str] = None) -> None:
+    def set_response(self, code: int, message: str | None = None) -> None:
         """
         Sets the response line.
         This method should be the first called when sending an answer.
@@ -263,7 +256,7 @@ class _SyncHTTPServletResponse(http.AbstractHTTPServletResponse):
         :param message: Associated message
         """
         if self._headers_set:
-            raise IOError("Headers have already been set, cannot change the response code")
+            raise OSError("Headers have already been set, cannot change the response code")
 
         self._code = code
         self._message = message
@@ -277,7 +270,7 @@ class _SyncHTTPServletResponse(http.AbstractHTTPServletResponse):
         :param value: Header value
         """
         if self._headers_set:
-            raise IOError("Headers have already been set, cannot change them")
+            raise OSError("Headers have already been set, cannot change them")
 
         if value is None:
             self._headers.pop(name.lower(), None)
@@ -345,11 +338,7 @@ class _AsyncHTTPServletRequest(http.AbstractAsyncHTTPServletRequest):
         self._prefix = prefix
 
         # Compute the sub path
-        self._sub_path = full_path[len(prefix) :]
-        if not self._sub_path.startswith("/"):
-            self._sub_path = f"/{self._sub_path}"
-
-        self._sub_path = re.sub("/+", "/", self._sub_path)
+        self._sub_path = compute_sub_path(full_path, prefix)
 
     def get_command(self) -> str:
         """
@@ -357,7 +346,7 @@ class _AsyncHTTPServletRequest(http.AbstractAsyncHTTPServletRequest):
         """
         return self._request.method.upper()
 
-    def get_client_address(self) -> Tuple[str, int]:
+    def get_client_address(self) -> tuple[str, int]:
         """
         Retrieves the address of the client
 
@@ -365,24 +354,24 @@ class _AsyncHTTPServletRequest(http.AbstractAsyncHTTPServletRequest):
         """
         if self._request.transport is None:
             # No transport, no address
-            raise IOError("No transport available for the request")
+            raise OSError("No transport available for the request")
 
         peer_name = self._request.transport.get_extra_info("peername")
         if not peer_name:
-            raise IOError("No peer name available for the request")
+            raise OSError("No peer name available for the request")
         return peer_name[:2]
 
-    async def get_header(self, name: str, default: Optional[Any] = None) -> Any:
+    async def get_header(self, name: str, default: Any | None = None) -> Any:
         """
         Retrieves the value of a header
         """
         return self._request.headers.get(name, default)
 
-    async def get_headers(self) -> Dict[str, Any]:
+    async def get_headers(self) -> dict[str, Any]:
         """
         Retrieves all headers
         """
-        return cast(Dict[str, Any], self._request.headers)
+        return cast(dict[str, Any], self._request.headers)
 
     def get_path(self) -> str:
         """
@@ -455,7 +444,7 @@ class _AsyncHTTPServletResponse(http.AbstractAsyncHTTPServletResponse):
         """
         return self._response
 
-    def set_response(self, code: int, message: Optional[str] = None) -> None:
+    def set_response(self, code: int, message: str | None = None) -> None:
         """
         Sets the response line.
         This method should be the first called when sending an answer.
@@ -464,7 +453,7 @@ class _AsyncHTTPServletResponse(http.AbstractAsyncHTTPServletResponse):
         :param message: Associated message
         """
         if self._headers_set:
-            raise IOError("Headers have already been set, cannot change the response code")
+            raise OSError("Headers have already been set, cannot change the response code")
 
         self._response.set_status(code, message)
 
@@ -477,7 +466,7 @@ class _AsyncHTTPServletResponse(http.AbstractAsyncHTTPServletResponse):
         :param value: Header value
         """
         if self._headers_set:
-            raise IOError("Headers have already been set, cannot change them")
+            raise OSError("Headers have already been set, cannot change them")
 
         if value is None:
             self._response.headers.popall(name.lower(), None)
@@ -509,7 +498,7 @@ class _AsyncHTTPServletResponse(http.AbstractAsyncHTTPServletResponse):
             raise ValueError("Cannot set up SSE for a non-SSE request")
 
         if self._headers_set:
-            raise IOError("Headers have already been set, cannot change them")
+            raise OSError("Headers have already been set, cannot change them")
 
         self._response.headers["Content-Type"] = "text/event-stream"
         self._response.headers["Cache-Control"] = "no-cache"
@@ -553,7 +542,7 @@ class _AsyncHTTPServletResponse(http.AbstractAsyncHTTPServletResponse):
         :param id: Optional event ID (set to "" to reset the ID)
         """
         if not self._sse_set:
-            raise IOError("SSE not set up, call setup_sse() first")
+            raise OSError("SSE not set up, call setup_sse() first")
 
         # Prepare the SSE message
         parts: list[str] = []
@@ -583,7 +572,7 @@ class _AsyncHTTPServletResponse(http.AbstractAsyncHTTPServletResponse):
         try:
             await self.write("\n".join(parts).encode("utf-8"))
         except aiohttp.client_exceptions.ClientConnectionResetError:
-            raise IOError("Client connection reset during SSE send") from None
+            raise OSError("Client connection reset during SSE send") from None
 
 
 class WSSession(http.WebSocketSession):
@@ -604,7 +593,7 @@ class WSSession(http.WebSocketSession):
         self._request = servlet_request
         self._response = ws_response
 
-    def get_client_address(self) -> Tuple[str, int]:
+    def get_client_address(self) -> tuple[str, int]:
         """
         Returns the address of the client
 
@@ -619,7 +608,7 @@ class WSSession(http.WebSocketSession):
         :param message: Binary message to send
         """
         if self._response.closed:
-            raise IOError("WebSocket session is closed")
+            raise OSError("WebSocket session is closed")
 
         await self._response.send_bytes(message)
 
@@ -630,7 +619,7 @@ class WSSession(http.WebSocketSession):
         :param message: Message to send
         """
         if self._response.closed:
-            raise IOError("WebSocket session is closed")
+            raise OSError("WebSocket session is closed")
 
         await self._response.send_str(message)
 
@@ -654,64 +643,21 @@ class WSSession(http.WebSocketSession):
 @Requires("_servlets_async_services", http.AsyncServlet, True, True)
 @Requires("_websocket_handler_services", http.WebSocketHandler, True, True)
 @Requires("_error_handler", http.ErrorHandler, optional=True)
-@Property("_address", http.HTTP_SERVICE_ADDRESS, DEFAULT_BIND_ADDRESS)
-@Property("_port", http.HTTP_SERVICE_PORT, 8080)
-@Property("_uses_ssl", http.HTTP_USES_SSL, False)
-@Property("_cert_file", http.HTTPS_CERT_FILE, None)
-@Property("_key_file", http.HTTPS_KEY_FILE, None)
-@HiddenProperty("_key_password", http.HTTPS_KEY_PASSWORD, None)
-@Property("_extra", HTTP_SERVICE_EXTRA, None)
-@Property("_instance_name", constants.IPOPO_INSTANCE_NAME)
-@Property("_logger_name", "pelix.http.logger.name", "")
-@Property("_logger_level", "pelix.http.logger.level", None)
-@Property("_debug_errors", http.HTTP_DEBUG_ERRORS, False)
-class AsyncHttpServiceImpl(http.HTTPService):
+class AsyncHttpServiceImpl(AbstractHttpService):
     """
     Asynchronous HTTP service component
     """
 
     def __init__(self) -> None:
-        # Properties
-        self._address = "0.0.0.0"
-        self._port = 8080
-        self._uses_ssl = False
-        self._debug_errors = False
-        self._extra: Optional[Dict[str, Any]] = None
-        self._instance_name: Optional[str] = None
-        self._logger_name: Optional[str] = None
-        self._logger_level: str | int | None = None
+        super().__init__()
 
-        # SSL Parameters
-        self._cert_file: Optional[str] = None
-        self._key_file: Optional[str] = None
-        self._key_password: Optional[str] = None
-
-        # Validation flag
-        self._validated = False
-
-        # The logger
-        self._logger: logging.Logger = logging.getLogger(f"{__name__}#init")
-
-        # Servlets registry lock
-        self._lock = threading.RLock()
-
-        # Path -> (servlet, parameters, type)
-        self._servlets: Dict[
-            str, Tuple[http.Servlet | http.AsyncServlet, Dict[str, Any], http.ServletType]
-        ] = {}
+        # This implementation always has a logger
+        self._logger = logging.getLogger(f"{__name__}#init")
 
         # Fields injected by iPOPO
-        self._servlets_services: List[http.Servlet] = []
-        self._servlets_async_services: List[http.AsyncServlet] = []
-        self._websocket_handler_services: List[http.WebSocketHandler] = []
-        self._error_handler: Optional[http.ErrorHandler] = None
-
-        # Servlet -> ServiceReference
-        self._servlets_refs: Dict[
-            http.Servlet | http.AsyncServlet | http.WebSocketHandler,
-            ServiceReference[http.Servlet | http.AsyncServlet | http.WebSocketHandler],
-        ] = {}
-        self._binding_lock = threading.RLock()
+        self._servlets_services: list[http.Servlet] = []
+        self._servlets_async_services: list[http.AsyncServlet] = []
+        self._websocket_handler_services: list[http.WebSocketHandler] = []
 
         # Server control
         self._bound_address: tuple[str, int] | None = None
@@ -723,60 +669,13 @@ class AsyncHttpServiceImpl(http.HTTPService):
         self._stop_event: asyncio.Event = asyncio.Event()
         self._stop_done_event: threading.Event = threading.Event()
 
-    def __str__(self) -> str:
-        """
-        String representation of the instance
-        """
-        return f"BasicHttpService({self._address}, {self._port})"
-
     @Validate
     def validate(self, context: "BundleContext") -> None:
         """
         Component validated
         """
-        # Check if we'll use an SSL connection
-        self._uses_ssl = self._cert_file is not None
-
-        if not self._address:
-            # No address given, use the localhost address
-            self._address = LOCALHOST_ADDRESS
-
-        if self._port is None:
-            # Random port
-            self._port = 0
-        else:
-            # Ensure we have an integer
-            self._port = int(self._port)
-            if self._port < 0:
-                # Random port
-                self._port = 0
-
-        # Normalize the extra properties
-        if not isinstance(self._extra, dict):
-            self._extra = {}
-
-        # Set up the logger
-        if not self._logger_name:
-            # Empty name, use the instance name
-            self._logger_name = self._instance_name
-
-        self._logger = logging.getLogger(self._logger_name)
-
-        level: int | None = None
-        if self._logger_level is None:
-            level = logging.INFO
-        elif isinstance(self._logger_level, int):
-            level = self._logger_level
-        else:
-            level = utilities.get_log_level(self._logger_level)
-            if level is None:
-                try:
-                    level = int(self._logger_level)
-                except ValueError:
-                    # Invalid level
-                    level = None
-
-        self._logger.level = level if level is not None else logging.INFO
+        self._normalize_configuration()
+        self._setup_logger()
 
         self.log(
             logging.INFO,
@@ -802,23 +701,18 @@ class AsyncHttpServiceImpl(http.HTTPService):
         # Wait for the server to be ready
         if not self._start_done_event.wait(10):
             self._logger.error("HTTP server did not start in time")
-            raise IOError("HTTP server did not start in time")
+            raise OSError("HTTP server did not start in time")
 
         if self._start_done_event.data is None:
             self._logger.error("HTTP server did not bind to an address")
-            raise IOError("HTTP server did not bind to an address")
+            raise OSError("HTTP server did not bind to an address")
 
         host, port = self._start_done_event.data
         self._bound_address = (host, port)
         self._port = port
 
-        with self._binding_lock:
-            # Set the validation flag up, once the server is ready
-            self._validated = True
-
-            # Register bound servlets
-            for service, svc_ref in self._servlets_refs.items():
-                self.__register_servlet_service(service, svc_ref)
+        # Register the servlets bound before the server was ready
+        self._register_bound_servlets()
 
         self._logger.info(
             "HTTP%s server bound to: [%s]:%d ...",
@@ -883,6 +777,7 @@ class AsyncHttpServiceImpl(http.HTTPService):
             # Set the event loop for this thread
             if sys.platform.startswith("win"):
                 # aiodns requires a specific event loop on Windows
+                # FIXME: this will be removed in Python 3.16
                 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
             self._loop = asyncio.new_event_loop()
@@ -959,13 +854,13 @@ class AsyncHttpServiceImpl(http.HTTPService):
             # No executor available, cannot handle the request
             return aiohttp.web.Response(status=503, text="Service unavailable")
 
-        # Remove the double-slashes in the request path
-        path = re.sub("/+", "/", request.path)
-
         # Get the corresponding servlet
-        found_servlet = self.get_servlet(path)
-        if found_servlet is not None:
-            servlet, _, prefix, servlet_type = found_servlet
+        routing = self.resolve_request(request.path)
+        path = routing.path
+        servlet = routing.servlet
+        if servlet is not None:
+            prefix = routing.prefix
+            servlet_type = routing.servlet_type
 
             async_name = f"do_async_{request.method.upper()}"
             sync_name = f"do_{request.method.upper()}"
@@ -1041,11 +936,12 @@ class AsyncHttpServiceImpl(http.HTTPService):
                                     case aiohttp.WSMsgType.TEXT:
                                         # Text message received
                                         await ws_handler.ws_message(ws_session, msg.data)
-                            else:
-                                code = ws_response.close_code or aiohttp.WSCloseCode.GOING_AWAY
-                                await ws_handler.ws_close(ws_session, code, "Session closed")
+
+                            # End of loop: the WebSocket connection is closed
+                            code = ws_response.close_code or aiohttp.WSCloseCode.GOING_AWAY
+                            await ws_handler.ws_close(ws_session, code, "Session closed")
                         except Exception as ex:
-                            self._logger.exception("Error handling WebSocket connection: %s", ex)
+                            self._logger.exception("Error handling WebSocket connection")
                             await ws_handler.ws_error(ws_session, str(ex))
                         finally:
                             if not ws_response.closed:
@@ -1077,45 +973,19 @@ class AsyncHttpServiceImpl(http.HTTPService):
         # Send the page
         return aiohttp.web.Response(status=500, text=self.make_exception_page(path, stack))
 
-    def __safe_callback(self, instance: http.Servlet, method: str, *args: Any, **kwargs: Any) -> Any:
+    def _set_extra_parameters(self, parameters: dict[str, Any], servlet_type: http.ServletType) -> None:
         """
-        Safely calls the given method in the given instance.
-        Returns True on method absence.
-        Returns False on error.
-        Returns the method result if found.
+        Tells the servlet if it is registered in asynchronous mode
 
-        :param instance: The instance to call
-        :param method: The method to call in the instance
-        :return: The method result or True on method absence or False on error
+        :param parameters: The parameters given to the servlet
+        :param servlet_type: The type of the servlet being registered
         """
-        # Call back the method
-        if instance is None:
-            # Consider invalidity as a failure
-            return False
+        parameters[http.PARAM_ASYNC] = servlet_type != http.ServletType.SYNC
 
-        try:
-            callback = getattr(instance, method)
-        except AttributeError:
-            # Consider absence as a success
-            return True
-
-        try:
-            result = callback(*args, **kwargs)
-            if result is None:
-                # Special case: consider None as success
-                return True
-
-            return result
-
-        except Exception as ex:
-            self.log_exception("Error calling back an instance: %s", ex)
-
-        return False
-
-    def __register_servlet_service(
+    def _register_servlet_service(
         self,
         service: http.Servlet | http.AsyncServlet | http.WebSocketHandler,
-        service_reference: ServiceReference[http.Servlet | http.AsyncServlet | http.WebSocketHandler],
+        service_reference: ServiceReference[Any],
     ) -> None:
         """
         Registers a servlet according to its service properties
@@ -1174,17 +1044,7 @@ class AsyncHttpServiceImpl(http.HTTPService):
         """
         Called by iPOPO when a service is bound
         """
-        # Ignore imported services
-        if self.__is_imported(service_reference):
-            self._logger.debug("Ignoring imported service as it is imported: %s", service_reference)
-            return
-
-        with self._binding_lock:
-            self._servlets_refs[service] = service_reference
-
-            if self._validated:
-                # We've been validated, register the service
-                self.__register_servlet_service(service, service_reference)
+        self._on_bind(service, service_reference)
 
     @UpdateField("_servlets_services")
     @UpdateField("_servlets_async_services")
@@ -1194,35 +1054,17 @@ class AsyncHttpServiceImpl(http.HTTPService):
         _: str,
         service: http.Servlet | http.AsyncServlet | http.WebSocketHandler,
         service_reference: ServiceReference[http.Servlet | http.AsyncServlet | http.WebSocketHandler],
-        old_properties: Dict[str, Any],
+        old_properties: dict[str, Any],
     ) -> None:
         """
         Called by iPOPO when the properties of a service have been updated
         """
-        # Ignore imported services
-        if self.__is_imported(service_reference):
-            return
-        # Check if the property concerns the registration
-        old_path = old_properties.get(http.HTTP_SERVLET_PATH)
-        new_path = service_reference.get_property(http.HTTP_SERVLET_PATH)
-
-        old_async_path = old_properties.get(http.HTTP_SERVLET_ASYNC_PATH)
-        new_async_path = service_reference.get_property(http.HTTP_SERVLET_ASYNC_PATH)
-
-        old_ws_path = old_properties.get(http.HTTP_WEBSOCKET_PATH)
-        new_ws_path = service_reference.get_property(http.HTTP_WEBSOCKET_PATH)
-
-        if old_path == new_path and old_async_path == new_async_path and old_ws_path == new_ws_path:
-            # Nothing to do
-            return
-
-        with self._binding_lock:
-            # Unregister the previous paths
-            self.unregister(None, service)
-
-            if self._validated:
-                # Register the service with its new properties
-                self.__register_servlet_service(service, service_reference)
+        self._on_update(
+            service,
+            service_reference,
+            old_properties,
+            (http.HTTP_SERVLET_PATH, http.HTTP_SERVLET_ASYNC_PATH, http.HTTP_WEBSOCKET_PATH),
+        )
 
     @UnbindField("_servlets_services")
     @UnbindField("_servlets_async_services")
@@ -1236,305 +1078,11 @@ class AsyncHttpServiceImpl(http.HTTPService):
         """
         Called by iPOPO when a service is gone
         """
-        # Ignore imported services
-        if self.__is_imported(service_reference):
-            return
+        self._on_unbind(service, service_reference)
 
-        with self._binding_lock:
-            # Servlet gone: unregister all paths associated to this servlet
-            self.unregister(None, service)
-
-            # Remove the service reference
-            try:
-                del self._servlets_refs[service]
-            except KeyError:
-                # Service reference not found, nothing to do
-                pass
-
-    def get_access(self) -> Tuple[str, int]:
+    def get_access(self) -> tuple[str, int]:
         """
         Retrieves the (address, port) tuple to access the server
         """
         assert self._bound_address is not None, "Server must be started before accessing its address"
         return self._bound_address
-
-    def get_hostname(self) -> str:
-        """
-        Retrieves the server host name
-
-        :return: The server host name
-        """
-        return socket.gethostname()
-
-    def is_https(self) -> bool:
-        """
-        Returns True if this is an HTTPS server
-
-        :return: True if this server uses SSL
-        """
-        return self._uses_ssl
-
-    def get_registered_paths(self) -> List[str]:
-        """
-        Returns the paths registered by servlets
-
-        :return: The paths registered by servlets (sorted list)
-        """
-        return sorted(self._servlets)
-
-    def get_servlet(
-        self, path: Optional[str]
-    ) -> Optional[Tuple[http.Servlet | http.AsyncServlet, Dict[str, Any], str, http.ServletType]]:
-        """
-        Retrieves the servlet matching the given path and its parameters.
-        Returns None if no servlet matches the given path.
-
-        :param path: A request URI
-        :return: A tuple (servlet, parameters, prefix, type) or None
-        """
-        if not path or path[0] != "/":
-            # No path, nothing to return
-            return None
-
-        # Use lower case for comparison
-        path = path.lower()
-
-        if path[-1] != "/":
-            # Add a trailing slash
-            path += "/"
-
-        with self._lock:
-            longest_match = ""
-            longest_match_len = 0
-            for servlet_path in self._servlets:
-                tested_path = servlet_path
-                if tested_path[-1] != "/":
-                    # Add a trailing slash
-                    tested_path += "/"
-
-                if path.startswith(tested_path) and len(servlet_path) > longest_match_len:
-                    # Found a corresponding servlet
-                    # which is deeper than the previous one
-                    longest_match = servlet_path
-                    longest_match_len = len(servlet_path)
-
-            # Return the found servlet
-            if not longest_match:
-                # No match found
-                return None
-
-            # Retrieve the stored information
-            servlet, params, servlet_type = self._servlets[longest_match]
-            return servlet, params, longest_match, servlet_type
-
-    def make_not_found_page(self, path: str) -> str:
-        """
-        Prepares a "page not found" page for a 404 error
-
-        :param path: Request path
-        :return: A HTML page
-        """
-        page = None
-        if self._error_handler is not None:
-            page = self._error_handler.make_not_found_page(path)
-
-        if not page:
-            page = f"""<html>
-<head>
-<title>404 - Page not found</title>
-</head>
-<body>
-<h1>Page not found</h1>
-<p>No servlet is associated to this path:</p>
-<code>{html.escape(path)}</code>
-<h2>Registered paths:</h2>
-{http.make_html_list(self.get_registered_paths())}
-</body>
-</html>"""
-        return page
-
-    def make_exception_page(self, path: str, stack: str) -> str:
-        """
-        Prepares a page describing an error in a 500 error page.
-
-        The stack trace is only sent to the client if the
-        :const:`pelix.http.HTTP_DEBUG_ERRORS` property is set: it gives details
-        about the server and about the data it handles. It is always logged,
-        along with the error ID shown in the page.
-
-        :param path: Request path
-        :param stack: Exception stack trace
-        :return: A HTML page
-        """
-        # Log the details of the error, they are not sent to the client
-        error_id = uuid.uuid4().hex
-        self._logger.error("Error %s handling request upon: %s\n%s", error_id, path, stack)
-
-        # Only tell the client how to find the error in the logs
-        details = stack if self._debug_errors else f"Error ID: {error_id}"
-
-        page = None
-        if self._error_handler is not None:
-            page = self._error_handler.make_exception_page(path, details)
-
-        if not page:
-            page = f"""<html>
-<head>
-<title>500 - Internal Server Error</title>
-</head>
-<body>
-<h1>Internal Server Error</h1>
-<p>Error handling request upon: <code>{html.escape(path)}</code></p>
-<pre>
-{html.escape(details)}
-</pre>
-</body>
-</html>"""
-        return page
-
-    def register_servlet(
-        self,
-        path: str,
-        servlet: http.Servlet | http.AsyncServlet,
-        parameters: Optional[Dict[str, Any]] = None,
-        servlet_type: http.ServletType = http.ServletType.SYNC,
-    ) -> bool:
-        """
-        Registers a servlet
-
-        :param path: Path handled by this servlet
-        :param servlet: The servlet instance
-        :param parameters: The parameters associated to this path
-        :param servlet_type: The type of servlet (sync, async, websocket, ...)
-        :return: True if the servlet has been registered, False if it refused the binding.
-        :raise ValueError: Invalid path or handler
-        """
-        if servlet is None:
-            raise ValueError("Invalid servlet instance")
-
-        if not path or path[0] != "/":
-            raise ValueError("Invalid path given to register the servlet: {0}".format(path))
-
-        # Use lower-case paths
-        path = path.lower()
-
-        # Prepare the parameters
-        if parameters is None:
-            parameters = {}
-
-        with self._lock:
-            if path in self._servlets:
-                # Already registered path
-                if self._servlets[path][0] is servlet:
-                    # Double-registration: Nothing to do
-                    return True
-                else:
-                    # Path is already taken by another servlet
-                    already_taken = True
-            else:
-                # Path is available
-                already_taken = False
-
-            # Add server information in parameters
-            parameters[http.PARAM_ADDRESS] = self._address
-            parameters[http.PARAM_PORT] = self._port
-            parameters[http.PARAM_HTTPS] = self._uses_ssl
-            parameters[http.PARAM_NAME] = self._instance_name
-            parameters[http.PARAM_EXTRA] = self._extra.copy() if self._extra else None
-            parameters[http.PARAM_ASYNC] = servlet_type != http.ServletType.SYNC
-
-            # The servlet might refuse to be bound to this server
-            if not self.__safe_callback(servlet, "accept_binding", path, parameters):
-                # Server refused: stop right there
-                # => No need to raise the "already taken path" exception
-                return False
-
-            if already_taken:
-                # The path is already taken by another servlet
-                raise ValueError("A servlet is already registered on {0}".format(path))
-
-            # Tell the servlet it can be bound to the path
-            if self.__safe_callback(servlet, "bound_to", path, parameters):
-                # Store the servlet
-                self._servlets[path] = (servlet, parameters, servlet_type)
-                return True
-
-            # The servlet refused the binding
-            return False
-
-    def unregister(self, path: Optional[str], servlet: Optional[http.Servlet] = None) -> bool:
-        """
-        Unregisters the servlet for the given path
-
-        :param path: The path to a servlet
-        :param servlet: If given, unregisters all the paths handled by this servlet
-        :return: True if at least one path as been unregistered, else False
-        """
-        if servlet is not None:
-            with self._lock:
-                # Unregister all paths for this servlet
-                paths = [
-                    servlet_path
-                    for (servlet_path, servlet_info) in self._servlets.items()
-                    if servlet_info[0] == servlet
-                ]
-
-            result = False
-            for servlet_path in paths:
-                result |= self.unregister(servlet_path)
-
-            return result
-        else:
-            if not path:
-                # Invalid path
-                return False
-
-            # Always use lower case to compare paths
-            path = path.lower()
-
-            with self._lock:
-                # Notify the servlet
-                servlet_info = self._servlets.get(path)
-                if servlet_info is None:
-                    # Unknown path
-                    return False
-
-                self.__safe_callback(servlet_info[0], "unbound_from", path, servlet_info[1])
-
-                # Remove the servlet
-                try:
-                    del self._servlets[path]
-                except KeyError:
-                    self.log(logging.DEBUG, "Tried to remove an unknown servlet path: %s", path)
-                return True
-
-    def log(self, level: int, message: str, *args: Any, **kwargs: Any) -> None:
-        """
-        Logs the given message
-
-        :param level: Log entry level
-        :param message: Log message (Python logging format)
-        """
-        if self._logger is not None:
-            # Log the message
-            self._logger.log(level, message, *args, **kwargs)
-
-    def log_exception(self, message: str, *args: Any, **kwargs: Any) -> None:
-        """
-        Logs an exception
-
-        :param message: Log message (Python logging format)
-        """
-        if self._logger is not None:
-            # Log the exception
-            self._logger.exception(message, *args, **kwargs)
-
-    @staticmethod
-    def __is_imported(service_reference: ServiceReference[Any]) -> bool:
-        """
-        Tests if the given service has been imported by Remote Services
-
-        :param service_reference: The reference of the service to check
-        :return: True if the service is flagged as imported
-        """
-        return cast(bool, service_reference.get_property(pelix.remote.PROP_IMPORTED))

--- a/pelix/http/basic_async.py
+++ b/pelix/http/basic_async.py
@@ -41,8 +41,7 @@ import aiohttp.client_exceptions
 import aiohttp.web
 
 import pelix.constants as fw_constants
-import pelix.http as http
-import pelix.utilities as utilities
+from pelix import http, utilities
 from pelix.http._base import (
     DEFAULT_BIND_ADDRESS,
     HTTP_SERVICE_EXTRA,

--- a/pelix/http/routing.py
+++ b/pelix/http/routing.py
@@ -7,7 +7,7 @@ of HTTP requests.
 :author: Thomas Calmant
 :copyright: Copyright 2026, Thomas Calmant
 :license: Apache License 2.0
-:version: 3.2.1
+:version: 3.2.2
 
 ..
 
@@ -29,7 +29,9 @@ of HTTP requests.
 import inspect
 import re
 import uuid
-from typing import Any, Callable, Dict, Iterable, List, Optional, Pattern, Tuple
+from collections.abc import Callable, Iterable
+from re import Pattern
+from typing import Any
 
 from pelix.http import AbstractHTTPServletRequest, AbstractHTTPServletResponse, Servlet
 from pelix.utilities import get_method_arguments
@@ -37,7 +39,7 @@ from pelix.utilities import get_method_arguments
 # ------------------------------------------------------------------------------
 
 # Module version
-__version_info__ = (3, 2, 1)
+__version_info__ = (3, 2, 2)
 __version__ = ".".join(str(x) for x in __version_info__)
 
 # Documentation strings format
@@ -61,7 +63,7 @@ Name of the attribute injected in methods to indicate their configuration
 # any 	    matches one of the items provided
 
 # Type name -> regex pattern
-TYPE_PATTERNS: Dict[Optional[str], str] = {
+TYPE_PATTERNS: dict[str | None, str] = {
     "string": r"(?:[^/]+)",
     "int": r"(?:[+\-]?\d+)",
     "float": r"(?:[+\-]?\d+\.?\d*)",
@@ -87,7 +89,7 @@ def path_filter(path: str) -> str:
 
 
 # Type name -> conversion method (for types other than str)
-TYPE_CONVERTERS: Dict[str, Callable[[str], Any]] = {
+TYPE_CONVERTERS: dict[str, Callable[[str], Any]] = {
     "int": int,
     "float": float,
     "path": path_filter,
@@ -102,7 +104,7 @@ class Http:
     Decorator indicating which route a method handles
     """
 
-    def __init__(self, route: str, methods: Optional[Iterable[str]] = None) -> None:
+    def __init__(self, route: str, methods: Iterable[str] | None = None) -> None:
         """
         :param route: Path handled by the method (beginning with a '/')
         :param methods: List of HTTP methods allowed (GET, POST, ...)
@@ -132,7 +134,7 @@ class Http:
             raise TypeError(f"@Http can decorate only methods, not {type(decorated_method).__name__}")
 
         try:
-            config: Dict[str, Any] = getattr(decorated_method, HTTP_ROUTE_ATTRIBUTE)
+            config: dict[str, Any] = getattr(decorated_method, HTTP_ROUTE_ATTRIBUTE)
         except AttributeError:
             config = {}
             setattr(decorated_method, HTTP_ROUTE_ATTRIBUTE, config)
@@ -217,10 +219,10 @@ class RestDispatcher(Servlet):
         Looks for the methods where to dispatch requests
         """
         # HTTP verb -> route pattern -> function
-        self.__routes: Dict[str, Dict[Pattern[str], Callable[..., None]]] = {}
+        self.__routes: dict[str, dict[Pattern[str], Callable[..., None]]] = {}
 
         # function -> arg name -> arg converter
-        self.__methods_args: Dict[Callable[..., None], Dict[str, Optional[Callable[[str], Any]]]] = {}
+        self.__methods_args: dict[Callable[..., None], dict[str, Callable[[str], Any] | None]] = {}
 
         # Find all REST methods
         self._setup_rest_dispatcher()
@@ -276,7 +278,7 @@ class RestDispatcher(Servlet):
         # Find the best matching method, according to the number of
         # readable arguments
         max_valid_args = -1
-        best_method: Optional[Callable[..., None]] = None
+        best_method: Callable[..., None] | None = None
         best_args = None
         best_match = None
 
@@ -365,7 +367,7 @@ class RestDispatcher(Servlet):
                     self.__routes.setdefault(http_verb, {})[pattern] = method
 
     @staticmethod
-    def __convert_route(route: str) -> Tuple[Pattern[str], Dict[str, Optional[Callable[[str], Any]]]]:
+    def __convert_route(route: str) -> tuple[Pattern[str], dict[str, Callable[[str], Any] | None]]:
         """
         Converts a route pattern into a regex.
         The result is a tuple containing the regex pattern to match and a
@@ -376,9 +378,9 @@ class RestDispatcher(Servlet):
         :param route: A route string, i.e. a path with type markers
         :return: A tuple (pattern, {argument name: converter})
         """
-        arguments: Dict[str, Optional[Callable[[str], Any]]] = {}
+        arguments: dict[str, Callable[[str], Any] | None] = {}
         last_idx = 0
-        final_pattern: List[str] = []
+        final_pattern: list[str] = []
         match_iter = _MARKER_PATTERN.finditer(route)
         for match_pattern in match_iter:
             # Copy intermediate string

--- a/pelix/http/routing.py
+++ b/pelix/http/routing.py
@@ -154,7 +154,7 @@ class HttpGet(Http):
         """
         :param route: Path handled by the method (beginning with a '/')
         """
-        super(HttpGet, self).__init__(route, methods=["GET"])
+        super().__init__(route, methods=["GET"])
 
 
 class HttpHead(Http):
@@ -166,7 +166,7 @@ class HttpHead(Http):
         """
         :param route: Path handled by the method (beginning with a '/')
         """
-        super(HttpHead, self).__init__(route, methods=["HEAD"])
+        super().__init__(route, methods=["HEAD"])
 
 
 class HttpPost(Http):
@@ -178,7 +178,7 @@ class HttpPost(Http):
         """
         :param route: Path handled by the method (beginning with a '/')
         """
-        super(HttpPost, self).__init__(route, methods=["POST"])
+        super().__init__(route, methods=["POST"])
 
 
 class HttpPut(Http):
@@ -190,7 +190,7 @@ class HttpPut(Http):
         """
         :param route: Path handled by the method (beginning with a '/')
         """
-        super(HttpPut, self).__init__(route, methods=["PUT"])
+        super().__init__(route, methods=["PUT"])
 
 
 class HttpDelete(Http):
@@ -202,7 +202,7 @@ class HttpDelete(Http):
         """
         :param route: Path handled by the method (beginning with a '/')
         """
-        super(HttpDelete, self).__init__(route, methods=["DELETE"])
+        super().__init__(route, methods=["DELETE"])
 
 
 # ------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ line-length = 110
 
 [tool.ruff]
 line-length = 110
+ignore = [
+  # Let all modules have their shebang
+  "EXE001"
+]
 
 [tool.ruff.lint]
 extend-select = ["I"]

--- a/tests/http/test_base.py
+++ b/tests/http/test_base.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests the code shared by the HTTP service implementations.
+
+:author: Thomas Calmant
+"""
+
+import importlib.util
+import unittest
+from typing import Any
+
+import pelix.http as http
+from pelix.framework import Framework, FrameworkFactory
+from pelix.http._base import AbstractHttpService, compute_sub_path, normalize_request_path
+from pelix.http.basic import HttpServiceImpl
+from tests.http.utils import DEFAULT_HOST, get_http_page, install_ipopo, instantiate_server
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# ------------------------------------------------------------------------------
+
+
+class SimpleServlet:
+    """
+    A servlet which does nothing: only its identity matters here
+    """
+
+    def do_GET(self, request: Any, response: Any) -> None:
+        """
+        Does nothing
+        """
+
+
+def get_services() -> list[tuple[str, AbstractHttpService]]:
+    """
+    Returns the HTTP service implementations to test.
+    They are used outside of any framework: only the code shared by both
+    implementations is tested here.
+
+    :return: A list of (name, service) tuples
+    """
+    services: list[tuple[str, AbstractHttpService]] = [("basic", HttpServiceImpl())]
+    if importlib.util.find_spec("aiohttp") is not None:
+        from pelix.http.basic_async import AsyncHttpServiceImpl
+
+        services.append(("basic_async", AsyncHttpServiceImpl()))
+
+    return services
+
+
+# ------------------------------------------------------------------------------
+
+
+class NormalizeRequestPathTest(unittest.TestCase):
+    """
+    Tests the normalization of the path of an incoming request
+    """
+
+    def test_query_string_is_removed(self) -> None:
+        """
+        The query string must not be part of the path used for routing
+        """
+        self.assertEqual(normalize_request_path("/path?a=1"), "/path")
+        self.assertEqual(normalize_request_path("/path?a=1?b=2"), "/path")
+        self.assertEqual(normalize_request_path("/path?"), "/path")
+
+    def test_slashes_are_collapsed(self) -> None:
+        """
+        Any sequence of consecutive slashes must be collapsed into a single one
+        """
+        for raw, expected in (
+            ("/a/b", "/a/b"),
+            ("/a//b", "/a/b"),
+            ("/a///b", "/a/b"),
+            ("//a////b//", "/a/b/"),
+            ("////", "/"),
+        ):
+            with self.subTest(raw=raw):
+                self.assertEqual(normalize_request_path(raw), expected)
+
+    def test_trailing_slash_is_kept(self) -> None:
+        """
+        A single trailing slash is meaningful and must be kept
+        """
+        self.assertEqual(normalize_request_path("/path/"), "/path/")
+        self.assertEqual(normalize_request_path("/path/?a=1"), "/path/")
+
+    def test_is_idempotent(self) -> None:
+        """
+        Normalizing an already normalized path must not change it
+        """
+        for raw in ("/", "/a/b", "/a/b/", "/a%2Fb"):
+            with self.subTest(raw=raw):
+                self.assertEqual(normalize_request_path(normalize_request_path(raw)), raw)
+
+
+class ComputeSubPathTest(unittest.TestCase):
+    """
+    Tests the computation of the servlet-relative path
+    """
+
+    def test_simple_prefix(self) -> None:
+        """
+        Basic computation of the sub path
+        """
+        self.assertEqual(compute_sub_path("/prefix/sub", "/prefix"), "/sub")
+        self.assertEqual(compute_sub_path("/prefix/sub/", "/prefix"), "/sub/")
+
+    def test_prefix_with_trailing_slash(self) -> None:
+        """
+        The prefix can end with a slash
+        """
+        self.assertEqual(compute_sub_path("/prefix/sub", "/prefix/"), "/sub")
+
+    def test_exact_match(self) -> None:
+        """
+        A request on the prefix itself has a root sub path
+        """
+        self.assertEqual(compute_sub_path("/prefix", "/prefix"), "/")
+        self.assertEqual(compute_sub_path("/prefix/", "/prefix"), "/")
+
+    def test_slashes_are_collapsed(self) -> None:
+        """
+        The sub path must not contain sequences of slashes either
+        """
+        self.assertEqual(compute_sub_path("/prefix///sub", "/prefix"), "/sub")
+        self.assertEqual(compute_sub_path("/prefix/sub//other", "/prefix"), "/sub/other")
+
+    def test_root_prefix(self) -> None:
+        """
+        The root prefix is a valid one
+        """
+        self.assertEqual(compute_sub_path("/sub", "/"), "/sub")
+
+
+# ------------------------------------------------------------------------------
+
+
+class ResolveRequestTest(unittest.TestCase):
+    """
+    Tests the routing seam shared by both implementations
+    """
+
+    def test_no_servlet(self) -> None:
+        """
+        The routing result must give the normalized path even without a servlet
+        """
+        for name, service in get_services():
+            with self.subTest(service=name):
+                routing = service.resolve_request("/unknown//path?a=1")
+                self.assertIsNone(routing.servlet)
+                self.assertEqual(routing.path, "/unknown/path")
+
+    def test_servlet_is_found(self) -> None:
+        """
+        A registered servlet must be found, with its prefix
+        """
+        servlet = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                self.assertTrue(service.register_servlet("/test", servlet))
+
+                routing = service.resolve_request("/test/sub")
+                self.assertIs(routing.servlet, servlet)
+                self.assertEqual(routing.prefix, "/test")
+                self.assertEqual(routing.path, "/test/sub")
+                self.assertIs(routing.servlet_type, http.ServletType.SYNC)
+
+    def test_query_string_does_not_break_routing(self) -> None:
+        """
+        The query string must not be taken into account to find the servlet
+        """
+        servlet = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                service.register_servlet("/test", servlet)
+
+                routing = service.resolve_request("/test/sub?a=1&b=2")
+                self.assertIs(routing.servlet, servlet)
+                self.assertEqual(routing.path, "/test/sub")
+
+    def test_repeated_slashes_reach_the_same_servlet(self) -> None:
+        """
+        Both implementations must agree on the servlet handling a path with
+        sequences of slashes: this used to differ between them
+        """
+        servlet = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                service.register_servlet("/test", servlet)
+
+                reference = service.resolve_request("/test/sub")
+                for raw in ("/test//sub", "/test///sub", "//test////sub"):
+                    with self.subTest(raw=raw):
+                        routing = service.resolve_request(raw)
+                        self.assertIs(routing.servlet, servlet)
+                        self.assertEqual(routing.path, reference.path)
+                        self.assertEqual(routing.prefix, reference.prefix)
+
+
+class ServletRegistryTest(unittest.TestCase):
+    """
+    Tests the servlets registry shared by both implementations
+    """
+
+    def test_get_servlet_returns_a_4_tuple(self) -> None:
+        """
+        The documented result of get_servlet must not have changed
+        """
+        servlet = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                service.register_servlet("/test", servlet, {"custom": 42})
+
+                found = service.get_servlet("/test/sub")
+                assert found is not None
+                self.assertEqual(len(found), 4)
+
+                found_servlet, params, prefix, servlet_type = found
+                self.assertIs(found_servlet, servlet)
+                self.assertEqual(params["custom"], 42)
+                self.assertEqual(prefix, "/test")
+                self.assertIs(servlet_type, http.ServletType.SYNC)
+
+    def test_unknown_path(self) -> None:
+        """
+        get_servlet must return None for an unhandled path
+        """
+        for name, service in get_services():
+            with self.subTest(service=name):
+                self.assertIsNone(service.get_servlet("/unknown"))
+                self.assertIsNone(service.get_servlet(""))
+                self.assertIsNone(service.get_servlet(None))
+                self.assertIsNone(service.get_servlet("no-leading-slash"))
+
+    def test_registered_paths(self) -> None:
+        """
+        The registered paths must be sorted
+        """
+        servlet = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                for path in ("/b", "/a", "/c"):
+                    service.register_servlet(path, servlet)
+
+                self.assertEqual(service.get_registered_paths(), ["/a", "/b", "/c"])
+
+    def test_invalid_registration(self) -> None:
+        """
+        Invalid servlets and paths must be refused
+        """
+        for name, service in get_services():
+            with self.subTest(service=name):
+                self.assertRaises(ValueError, service.register_servlet, "/test", None)
+                self.assertRaises(ValueError, service.register_servlet, "", SimpleServlet())
+                self.assertRaises(ValueError, service.register_servlet, "test", SimpleServlet())
+
+    def test_path_already_taken(self) -> None:
+        """
+        Two servlets can't share a path
+        """
+        for name, service in get_services():
+            with self.subTest(service=name):
+                service.register_servlet("/test", SimpleServlet())
+                self.assertRaises(ValueError, service.register_servlet, "/test", SimpleServlet())
+
+    def test_double_registration(self) -> None:
+        """
+        Registering the same servlet twice on the same path is a no-op
+        """
+        servlet = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                self.assertTrue(service.register_servlet("/test", servlet))
+                self.assertTrue(service.register_servlet("/test", servlet))
+                self.assertEqual(service.get_registered_paths(), ["/test"])
+
+    def test_unregister(self) -> None:
+        """
+        A servlet can be unregistered by path or by instance
+        """
+        servlet = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                service.register_servlet("/a", servlet)
+                service.register_servlet("/b", servlet)
+
+                self.assertTrue(service.unregister("/a"))
+                self.assertEqual(service.get_registered_paths(), ["/b"])
+
+                # Unknown path
+                self.assertFalse(service.unregister("/a"))
+                self.assertFalse(service.unregister(None))
+
+                # By instance
+                self.assertTrue(service.unregister(None, servlet))
+                self.assertEqual(service.get_registered_paths(), [])
+
+    def test_sync_service_refuses_async_servlets(self) -> None:
+        """
+        The synchronous implementation only supports synchronous servlets
+        """
+        service = HttpServiceImpl()
+        for servlet_type in (http.ServletType.ASYNC, http.ServletType.WEBSOCKET):
+            with self.subTest(servlet_type=servlet_type):
+                self.assertRaises(
+                    ValueError,
+                    service.register_servlet,
+                    "/test",
+                    SimpleServlet(),
+                    None,
+                    servlet_type,
+                )
+
+    def test_async_service_accepts_all_servlet_types(self) -> None:
+        """
+        The asynchronous implementation supports every kind of servlet
+        """
+        if importlib.util.find_spec("aiohttp") is None:
+            self.skipTest("aiohttp is not installed")
+
+        from pelix.http.basic_async import AsyncHttpServiceImpl
+
+        service = AsyncHttpServiceImpl()
+        for index, servlet_type in enumerate(http.ServletType):
+            with self.subTest(servlet_type=servlet_type):
+                path = f"/test{index}"
+                self.assertTrue(service.register_servlet(path, SimpleServlet(), None, servlet_type))
+
+                found = service.get_servlet(path)
+                assert found is not None
+                self.assertIs(found[3], servlet_type)
+
+                # The servlet must know how it has been registered
+                self.assertEqual(found[1][http.PARAM_ASYNC], servlet_type != http.ServletType.SYNC)
+
+
+# ------------------------------------------------------------------------------
+
+
+class EchoPathServlet:
+    """
+    A servlet which tells its name and which path it has been given
+    """
+
+    def __init__(self, name: str) -> None:
+        """
+        :param name: A name identifying this servlet in the responses
+        """
+        self._name = name
+
+    def do_GET(
+        self, request: http.AbstractHTTPServletRequest, response: http.AbstractHTTPServletResponse
+    ) -> None:
+        """
+        Sends back the name of the servlet, its prefix and the sub path
+        """
+        response.send_content(
+            200,
+            f"{self._name}|{request.get_prefix_path()}|{request.get_sub_path()}",
+            "text/plain",
+        )
+
+
+class EndToEndPathTest(unittest.TestCase):
+    """
+    Test routing over a real HTTP connection
+    """
+
+    framework: Framework
+
+    def setUp(self) -> None:
+        """
+        Starts a framework with an HTTP server on a random port
+        """
+        self.framework = FrameworkFactory.get_framework()
+        self.framework.start()
+
+        ipopo = install_ipopo(self.framework)
+        context = self.framework.get_bundle_context()
+        context.install_bundle("pelix.http.basic").start()
+
+        self.http_svc = instantiate_server(ipopo, http.FACTORY_HTTP_BASIC, "test-http-paths", port=0)
+        self.port = self.http_svc.get_access()[1]
+
+        # Two servlets, one nested in the other
+        self.http_svc.register_servlet("/test", EchoPathServlet("root"))
+        self.http_svc.register_servlet("/test/inner", EchoPathServlet("inner"))
+
+    def tearDown(self) -> None:
+        """
+        Cleans up the framework
+        """
+        self.framework.stop()
+        FrameworkFactory.delete_framework(self.framework)
+
+    def test_repeated_slashes_keep_the_deepest_servlet(self) -> None:
+        """
+        Adding slashes must not move the request from the deepest matching
+        servlet to a shallower one
+        """
+        for uri in (
+            "/test/inner/x",
+            "/test//inner/x",
+            "/test///inner/x",
+            "/test/inner//x",
+            "//test///inner////x",
+        ):
+            with self.subTest(uri=uri):
+                code, content = get_http_page(self.port, DEFAULT_HOST, uri)
+                self.assertEqual(code, 200, f"{uri} did not reach a servlet")
+                self.assertEqual(
+                    content.decode("utf-8"),
+                    "inner|/test/inner|/x",
+                    f"{uri} was not handled by the deepest servlet",
+                )
+
+    def test_repeated_slashes_on_the_shallow_servlet(self) -> None:
+        """
+        The servlet must always be given the same, fully collapsed, sub path
+        """
+        for uri in ("/test/sub", "/test//sub", "/test///sub", "/test////sub"):
+            with self.subTest(uri=uri):
+                code, content = get_http_page(self.port, DEFAULT_HOST, uri)
+                self.assertEqual(code, 200, f"{uri} did not reach the servlet")
+                self.assertEqual(content.decode("utf-8"), "root|/test|/sub")
+
+    def test_query_string_is_not_in_the_sub_path(self) -> None:
+        """
+        The query string must neither prevent the servlet from being found nor
+        appear in the sub path: it would break the regular expressions of the
+        REST-like router of pelix.http.routing
+        """
+        code, content = get_http_page(self.port, DEFAULT_HOST, "/test/inner/x?a=1")
+        self.assertEqual(code, 200)
+        self.assertEqual(content.decode("utf-8"), "inner|/test/inner|/x")
+
+    def test_sub_path_is_cut_at_the_right_place(self) -> None:
+        """
+        The sub path is computed by removing the prefix, which comes from the
+        normalized path: it must be cut from the normalized path too, else the
+        repeated slashes shift the cut and eat the beginning of the sub path
+        """
+        for uri, expected in (
+            ("/test/inner/abcdef", "/abcdef"),
+            ("/test//inner/abcdef", "/abcdef"),
+            ("/test///inner/abcdef", "/abcdef"),
+            ("/test/inner///abcdef", "/abcdef"),
+        ):
+            with self.subTest(uri=uri):
+                code, content = get_http_page(self.port, DEFAULT_HOST, uri)
+                self.assertEqual(code, 200)
+                self.assertEqual(content.decode("utf-8"), f"inner|/test/inner|{expected}")
+
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Moved shared code between `http.basic` and `http.basic_async` in an abstract class in `http._base`
- Updated typing syntax in the whole `pelix.http` package