### PR TITLE
Allow back XMPP tests on Python 3.15 CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -32,12 +32,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        # RSA (grpcio) and XMPP (pycares/cffi) have no prebuilt wheels for
-        # Python 3.15 yet: building them from source stalls the CI,
-        # so we skip them
+        # RSA (grpcio) has no prebuilt wheel for Python 3.15 yet: building it
+        # from source stalls on GitHub Actions, so skip it on 3.15 until
+        # upstream publishes cp315 wheels.
         run: |
           if [ "${{ matrix.python-version }}" = "3.15" ]; then
-            uv sync --python "${{ matrix.python-version }}" --all-extras --no-extra RSA --no-extra XMPP --locked
+            uv sync --python "${{ matrix.python-version }}" --all-extras --no-extra RSA --locked
           else
             uv sync --python "${{ matrix.python-version }}" --all-extras --locked
           fi

--- a/README.rst
+++ b/README.rst
@@ -525,12 +525,11 @@ Pelix and iPOPO are tested using
 `GitHub actions <https://github.com/tcalmant/ipopo/actions>`_
 targetting Python 3.10 to 3.15.
 
-``grpcio`` and ``pycares``, required by the ``RSA`` and ``XMPP`` extras,
-don't provide pre-built wheels for Python 3.15 yet.
-Their compilation from source stalls in CI and as a result, the CI skips
-those two extras on Python 3.15.
+``grpcio``, required by the ``RSA`` extra, doesn't provide pre-built wheels
+for Python 3.15 yet. Its compilation from source stalls in CI, so the CI
+skips that extra on Python 3.15.
 
-iPOPO v3 doesn't support Python 2 neither versions earlier than 3.10.
+iPOPO v3 doesn't support Python 2 nor versions earlier than 3.10.
 If you need to work with those versions of Python, please use iPOPO v1.
 You can then use Remote Services to allow interactions between iPOPO v1 and v3.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,13 +18,13 @@ use [iPOPO v1](https://github.com/tcalmant/ipopo/tree/v1).
 :::
 
 :::{note}
-``grpcio`` and ``pycares``, required by the ``RSA`` and ``XMPP`` extras,
-don't provide pre-built wheels for Python 3.15 yet.
+`grpcio`, required by the `RSA` extra, doesn't provide pre-built wheels for
+Python 3.15 yet. Its compilation from source stalls, which is why the
+project doesn't test that extra on Python 3.15: wait for an upstream wheel,
+or skip `RSA` when installing on Python 3.15.
 
-Their compilation from source stalls, which is why the project doesn't test
-those extras on Python 3.15.
-
-Wait for upstream wheels, or skip these two extras when installing on Python 3.15.
+`pycares`, required by the `XMPP` extra, has the same wheel gap, but its
+from-source build is quick, so `XMPP` isn't affected.
 :::
 
 There are many ways to install iPOPO, let's have a look to some of them.


### PR DESCRIPTION
Looks like XMPP extra stall was a side effect