### PR TITLE
Python 3.16 compatbility fix

### DIFF
--- a/pelix/http/basic_async.py
+++ b/pelix/http/basic_async.py
@@ -776,10 +776,10 @@ class AsyncHttpServiceImpl(AbstractHttpService):
             # Set the event loop for this thread
             if sys.platform.startswith("win"):
                 # aiodns requires a specific event loop on Windows
-                # FIXME: this will be removed in Python 3.16
-                asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+                self._loop = asyncio.SelectorEventLoop()
+            else:
+                self._loop = asyncio.new_event_loop()
 
-            self._loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self._loop)
 
             # Setup the server

--- a/pelix/http/basic_async.py
+++ b/pelix/http/basic_async.py
@@ -762,7 +762,21 @@ class AsyncHttpServiceImpl(AbstractHttpService):
 
         # Close the event loop
         if self._loop is not None and not self._loop.is_closed():
-            self._loop.close()
+            try:
+                # Cancel pending tasks
+                pending = [task for task in asyncio.all_tasks(self._loop) if not task.done()]
+                for task in pending:
+                    task.cancel()
+
+                if pending:
+                    self._loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+
+                self._loop.run_until_complete(self._loop.shutdown_asyncgens())
+                self._loop.run_until_complete(self._loop.shutdown_default_executor())
+            except Exception:
+                self._logger.exception("Error closing the event loop")
+            finally:
+                self._loop.close()
 
         # Clear references
         self._loop = None


### PR DESCRIPTION
- Replaced the call to set_event_loop_policy by a direct creation of a selector event loop on Windows
- Enhanced event loop shutdown in HTTP async server