### PR TITLE
Tests review

### DIFF
--- a/pelix/misc/mqtt_client.py
+++ b/pelix/misc/mqtt_client.py
@@ -110,6 +110,10 @@ class MqttClient:
         # Publication events
         self.__in_flight: dict[int, threading.Event] = {}
 
+        # Protects __in_flight: the publication can be notified by the network
+        # loop thread before publish() had a chance to store its event
+        self.__in_flight_lock = threading.Lock()
+
         # Assert protocol version
         try:
             protocol_version = MQTTProtocolVersion(protocol)
@@ -336,7 +340,10 @@ class MqttClient:
         self.__stop_timer()
 
         # Unlock all publishers
-        for event in self.__in_flight.values():
+        with self.__in_flight_lock:
+            pending = list(self.__in_flight.values())
+
+        for event in pending:
             event.set()
 
         # Disconnect from the server
@@ -369,17 +376,22 @@ class MqttClient:
         :param wait: If True, prepares an event to wait for the message to be published
         :return: The local message ID, None on error
         """
-        result = self.__mqtt.publish(topic, payload, qos, retain)
-        if result.rc != 0:
-            # No success
-            _logger.debug("Failed to publish message on %s: %d", topic, result.rc)
-            return None
+        # The message must be sent and its event stored atomically: the network
+        # loop thread can notify the publication as soon as the packet is sent,
+        # i.e. before this method returns. Without the lock, that notification
+        # would find no event to set and the waiter would block until timeout.
+        with self.__in_flight_lock:
+            result = self.__mqtt.publish(topic, payload, qos, retain)
+            if result.rc != 0:
+                # No success
+                _logger.debug("Failed to publish message on %s: %d", topic, result.rc)
+                return None
 
-        if wait:
-            # Publish packet sent, wait for it to return
-            self.__in_flight[result.mid] = threading.Event()
+            if wait:
+                # Publish packet sent, wait for it to return
+                self.__in_flight[result.mid] = threading.Event()
 
-        return result.mid
+            return result.mid
 
     def wait_publication(self, mid: int, timeout: float | None = None) -> bool:
         """
@@ -390,10 +402,13 @@ class MqttClient:
         :return: True if the message was published, False if timeout was raised
         :raise KeyError: Unknown waiting local message ID
         """
-        event = self.__in_flight[mid]
+        with self.__in_flight_lock:
+            event = self.__in_flight[mid]
+
         if event.wait(timeout):
             # Message published: no need to wait for it anymore
-            self.__in_flight.pop(mid)
+            with self.__in_flight_lock:
+                self.__in_flight.pop(mid, None)
             return True
 
         # Publication not sent yet
@@ -555,10 +570,11 @@ class MqttClient:
         :param mid: Message ID
         """
         # Unblock wait_publication, if any
-        try:
-            self.__in_flight[mid].set()
-        except KeyError:
-            pass
+        with self.__in_flight_lock:
+            event = self.__in_flight.get(mid)
+
+        if event is not None:
+            event.set()
 
         # Notify the explicit callback, if any
         if self.__on_publish_cb is not None:

--- a/pelix/misc/mqtt_client.py
+++ b/pelix/misc/mqtt_client.py
@@ -77,7 +77,8 @@ class MqttClient:
     ) -> None:
         """
         :param client_id: ID of the MQTT client
-        :param clean_session: If True, the broker will clean the client session on disconnect
+        :param clean_session: If True, the broker will clean the client session on disconnect.
+                              Forced to True if no client ID is given.
         :param protocol: MQTT protocol version (MQTTv31, MQTTv311 or MQTTv5)
         :param transport: Transport protocol (tcp or websockets)
         """
@@ -85,6 +86,12 @@ class MqttClient:
         if not client_id:
             # Randomize client ID
             self._client_id = self.generate_id()
+
+            # A generated ID is different on each run: the session kept by the
+            # broker could never be resumed, it would only pile up there
+            # (MQTT 3.1.1 sessions have no expiry), along with the messages
+            # queued for it. Only an explicit client ID can make use of it.
+            clean_session = True
         elif len(client_id) > 23:
             # ID too large
             _logger.warning(

--- a/tests/http/test_basic_ssl.py
+++ b/tests/http/test_basic_ssl.py
@@ -142,7 +142,7 @@ class BasicHTTPSTest(unittest.TestCase):
         key_file: str | None = None,
         password: str | None = None,
         address: str | None = DEFAULT_HOST,
-        port: int | None = DEFAULT_PORT,
+        port: int | None = 0,
     ) -> http.HTTPService:
         """
         Instantiates a basic server component
@@ -165,15 +165,19 @@ class BasicHTTPSTest(unittest.TestCase):
         """
         Tests the use of a certificate without password
         """
-        self.instantiate_server(cert_file="server.crt", key_file="server.key")
-        self.assertEqual(get_https_code(), 404, "Received something other than a 404")
+        srv = self.instantiate_server(cert_file="server.crt", key_file="server.key")
+        port = srv.get_access()[1]
+        self.assertEqual(get_https_code(port=port), 404, "Received something other than a 404")
 
     def testPasswordCertificate(self) -> None:
         """
         Tests the use of a certificate with a password
         """
-        self.instantiate_server(cert_file="server_enc.crt", key_file="server_enc.key", password=PASSWORD)
-        self.assertEqual(get_https_code(), 404, "Received something other than a 404")
+        srv = self.instantiate_server(
+            cert_file="server_enc.crt", key_file="server_enc.key", password=PASSWORD
+        )
+        port = srv.get_access()[1]
+        self.assertEqual(get_https_code(port=port), 404, "Received something other than a 404")
 
 
 # ------------------------------------------------------------------------------

--- a/tests/misc/test_mqtt.py
+++ b/tests/misc/test_mqtt.py
@@ -535,6 +535,29 @@ class MqttClientTest(unittest.TestCase):
         # Client ID must be kept as is
         self.assertEqual(client.client_id, long_id)
 
+    def test_clean_session(self) -> None:
+        """
+        Tests that a generated client ID implies a clean session: the broker
+        would keep the session of a random ID forever, without any way to
+        resume it
+        """
+        client_id: str | None
+
+        def is_clean(client: mqtt.MqttClient) -> bool:
+            """
+            Returns the clean session flag given to the underlying Paho client
+            """
+            paho_client = vars(client)["_MqttClient__mqtt"]
+            return bool(paho_client._clean_session)
+
+        # No ID given: the session can't be resumed, it must be cleaned
+        for client_id in (None, ""):
+            self.assertTrue(is_clean(mqtt.MqttClient(client_id)))
+
+        # Explicit ID: the caller decides
+        self.assertFalse(is_clean(mqtt.MqttClient("custom_id")))
+        self.assertTrue(is_clean(mqtt.MqttClient("custom_id", clean_session=True)))
+
     def test_topic_matches(self) -> None:
         """
         Tests the topic_matches() method

--- a/tests/misc/test_mqtt.py
+++ b/tests/misc/test_mqtt.py
@@ -469,6 +469,46 @@ class MqttClientTest(unittest.TestCase):
         self.assertEqual(msg.topic, msg_topic)
         self.assertEqual(to_str(msg.payload), msg_value)
 
+    def test_wait_publish_not_missed(self) -> None:
+        """
+        Tests that a publication notified while publish() is still running is
+        not missed: the network loop thread can call back before the event of
+        the message has been stored, which used to block the caller until the
+        end of its timeout
+        """
+        assert MQTT_SERVER is not None
+
+        msg_topic = f"pelix/test/mqtt/wait-race/{uuid.uuid4()!s}"
+
+        client = mqtt.MqttClient()
+        event_connect = EventData[None]()
+
+        def on_connect(clt: mqtt.MqttClient, result_code: int) -> None:
+            if result_code == 0:
+                event_connect.set()
+            else:
+                event_connect.raise_exception(RuntimeError(f"Connection failed with code {result_code}"))
+
+        client.on_connect = on_connect
+        client.connect(MQTT_SERVER)
+        try:
+            if not event_connect.wait(5):
+                self.fail("Connection timeout")
+
+            # Publish in a tight loop: the shorter the delay between the call to
+            # the Paho client and the storage of the event, the more likely the
+            # publication is notified in between
+            for idx in range(100):
+                mid = client.publish(msg_topic, f"value-{idx}", wait=True)
+                self.assertIsNotNone(mid)
+                assert mid is not None
+                self.assertTrue(
+                    client.wait_publication(mid, 5),
+                    f"Publication {idx} (mid={mid}) was not notified",
+                )
+        finally:
+            client.disconnect()
+
     def test_client_id(self) -> None:
         """
         Tests the generation of a client ID

--- a/tests/mqtt_utilities.py
+++ b/tests/mqtt_utilities.py
@@ -35,11 +35,28 @@ __docformat__ = "restructuredtext en"
 # ------------------------------------------------------------------------------
 
 
+MQTT_SERVER = "localhost"
+"""
+Host of the MQTT broker used by the tests: the one from tests-infra.
+
+Public brokers must not be used as a fallback: tests would publish their content
+on the Internet, depend on a third party, and each process looking for a server
+on its own could end up on a different broker than its peers.
+"""
+
+PUBLICATION_TIMEOUT = 10
+"""
+Time (in seconds) to wait for the test publication to be acknowledged.
+Kept large as a loaded machine can be slow to answer, and considering the broker
+as missing would only make tests fail later on, in a way harder to understand.
+"""
+
+
 def find_mqtt_server() -> str | None:
     """
-    Looks for a working server to run the tests
+    Checks if the MQTT broker of tests-infra is available
 
-    :return: The host name of a working MQTT server, else None
+    :return: The host name of the MQTT server, else None
     """
     try:
         from pelix.misc.mqtt_client import MqttClient
@@ -54,30 +71,26 @@ def find_mqtt_server() -> str | None:
 
     clt.on_disconnect = handle_disconnect
 
-    for server in ("localhost", "test.mosquitto.org", "iot.eclipse.org", "broker.hivemq.com"):
-        try:
-            # Try to connect
-            evt.clear()
-            clt.connect(server, blocking=True)
-        except OSError:
-            # Not available
-            pass
-        else:
-            try:
-                # Try publishing something
-                mid = clt.publish("/ipopo/test/bootstrap", "initial.data", wait=True)
-                if mid is None:
-                    # Error while publishing: next server
-                    continue
+    try:
+        # Try to connect
+        evt.clear()
+        clt.connect(MQTT_SERVER, blocking=True)
+    except OSError:
+        # Not available
+        return None
 
-                if clt.wait_publication(mid, 1):
-                    # Message sent without error and with a correct delay
-                    return server
-                elif evt.is_set():
-                    # Got disconnected while waiting
-                    continue
-            finally:
-                # Disconnect from the server
-                clt.disconnect()
+    try:
+        # Try publishing something
+        mid = clt.publish("/ipopo/test/bootstrap", "initial.data", wait=True)
+        if mid is None:
+            # Error while publishing
+            return None
+
+        if clt.wait_publication(mid, PUBLICATION_TIMEOUT):
+            # Message sent without error and with a correct delay
+            return MQTT_SERVER
+    finally:
+        # Disconnect from the server
+        clt.disconnect()
 
     return None

--- a/tests/remote/test_transports_mqtt.py
+++ b/tests/remote/test_transports_mqtt.py
@@ -127,11 +127,16 @@ class RemoteService:
 # ------------------------------------------------------------------------------
 
 
-def load_framework(app_id: str, transport: str, components: Iterable[tuple[str, str]]) -> Framework:
+def load_framework(
+    app_id: str, mqtt_server: str, transport: str, components: Iterable[tuple[str, str]]
+) -> Framework:
     """
     Starts a Pelix framework in the local process
 
     :param app_id: Application ID
+    :param mqtt_server: Host of the MQTT broker to use. It is given explicitly as
+                        the peer process is spawned, i.e. it reimports this module:
+                        looking for the broker on its own could give another result
     :param transport: Name of the transport bundle to install
     :param components: Tuples (factory, name) of instances to start
     """
@@ -152,30 +157,35 @@ def load_framework(app_id: str, transport: str, components: Iterable[tuple[str, 
         ipopo.instantiate(
             pelix.remote.FACTORY_DISCOVERY_MQTT,
             "mqtt-discovery",
-            {"mqtt.host": MQTT_SERVER, "application.id": app_id},
+            {"mqtt.host": mqtt_server, "application.id": app_id},
         )
 
         # Start other components
         for factory, name in components:
-            ipopo.instantiate(factory, name, {"mqtt.host": MQTT_SERVER})
+            ipopo.instantiate(factory, name, {"mqtt.host": mqtt_server})
 
     return framework
 
 
 def export_framework(
-    state_queue: Queue, app_id: str, transport: str, components: Iterable[tuple[str, str]]
+    state_queue: Queue,
+    app_id: str,
+    mqtt_server: str,
+    transport: str,
+    components: Iterable[tuple[str, str]],
 ) -> None:
     """
     Starts a Pelix framework, on the export side
 
     :param state_queue: Queue to store status
     :param app_id: Application ID
+    :param mqtt_server: Host of the MQTT broker to use
     :param transport: Name of the transport bundle to install
     :param components: Tuples (factory, name) of instances to start
     """
     try:
         # Load the framework
-        framework = load_framework(app_id, transport, components)
+        framework = load_framework(app_id, mqtt_server, transport, components)
         context = framework.get_bundle_context()
 
         # Register the exported service
@@ -219,6 +229,8 @@ class MqttTransportsTest(unittest.TestCase):
         :raise queue.Empty: Peer took to long to answer
         :raise ValueError: Test failed
         """
+        assert MQTT_SERVER is not None
+
         # Define components
         components = [(exporter_factory, "rs-exporter"), (importer_factory, "rs-importer")]
 
@@ -226,7 +238,8 @@ class MqttTransportsTest(unittest.TestCase):
         print("Starting...")
         status_queue = Queue()
         peer = WrappedProcess(
-            target=export_framework, args=(status_queue, APP_ID, transport_bundle, components)
+            target=export_framework,
+            args=(status_queue, APP_ID, MQTT_SERVER, transport_bundle, components),
         )
         peer.start()
 
@@ -237,7 +250,7 @@ class MqttTransportsTest(unittest.TestCase):
             self.assertEqual(state, "ready")
 
             # Load the local framework (after the fork)
-            framework = load_framework(APP_ID, transport_bundle, components)
+            framework = load_framework(APP_ID, MQTT_SERVER, transport_bundle, components)
             context = framework.get_bundle_context()
 
             # Look for the remote service

--- a/tests/shell/test_core.py
+++ b/tests/shell/test_core.py
@@ -618,8 +618,7 @@ class ShellCoreCommandsTest(unittest.TestCase):
         self.context.install_bundle("pelix.shell.ipopo").start()
 
         # Prepare a session
-        port = 9001
-        session = beans.ShellSession(beans.IOHandler(sys.stdin, sys.stdout), {"port": port})
+        session = beans.ShellSession(beans.IOHandler(sys.stdin, sys.stdout), {"port": 0})
 
         # Run the file a first time
         self.assertTrue(self.shell.execute(f"run '{filename}'", session))
@@ -632,10 +631,13 @@ class ShellCoreCommandsTest(unittest.TestCase):
         bundle = self.context.get_bundle(rshell_bundle)
         self.assertEqual(bundle.get_symbolic_name(), "pelix.shell.remote")
 
-        # Check the instance properties
+        # Check the instance properties: the requested port was 0 (OS-assigned),
+        # so check that a real port was bound instead of comparing against it
         with use_ipopo(self.context) as ipopo:
             details = ipopo.get_instance_details(session.get("rshell.name"))
-            self.assertEqual(int(details["properties"]["pelix.shell.port"]), port)
+            port = int(details["properties"]["pelix.shell.port"])
+            self.assertGreater(port, 0)
+            self.assertLess(port, 65536)
 
         # Run the file a second time: it must fail
         self.assertFalse(self.shell.execute(f"run '{filename}'", session))

--- a/tests/shell/test_remote.py
+++ b/tests/shell/test_remote.py
@@ -7,6 +7,7 @@ Tests the remote shell
 """
 
 import importlib.util
+import re
 import socket
 import sys
 import threading
@@ -147,21 +148,37 @@ class RemoteShellStandaloneTest(unittest.TestCase):
 
         ps1 = pelix.shell.core._ShellService.PS1
 
-        # Start the remote shell process
-        port = 9001
+        # Start the remote shell process, on a random port
         args = [sys.executable, "-m"]
         if has_coverage:
             args += ["coverage", "run", "-m"]
-        args += ["pelix.shell.remote", "-a", "127.0.0.1", "-p", str(port)]
+        args += ["pelix.shell.remote", "-a", "127.0.0.1", "-p", "0"]
         process = subprocess.Popen(
             args,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
+        assert process.stderr is not None
 
-        # Wait a little to ensure that the socket is here
-        time.sleep(1)
+        # Wait for the interactive console banner to report the bound port
+        # (see pelix.shell.remote.main(): interact() writes it to stderr)
+        # The trailing "\n" ensures the whole number was read, not just its first digit
+        port_re = re.compile(r"Remote shell bound to: [^:\n]+:(\d+)\n")
+        port = None
+        got = ""
+        banner_timer = threading.Timer(10, process.terminate)
+        banner_timer.start()
+        while port is None:
+            char = to_str(process.stderr.read(1))
+            if not char:
+                output = to_str(process.stderr.read())
+                self.fail(f"Process exited before printing its port (rc={process.returncode})\n{output}")
+            got += char
+            match = port_re.search(got)
+            if match:
+                port = int(match.group(1))
+        banner_timer.cancel()
 
         client = ShellClient(None, ps1, self.fail)
         try:
@@ -234,7 +251,7 @@ class RemoteShellTest(unittest.TestCase):
             self.remote = ipopo.instantiate(
                 FACTORY_REMOTE_SHELL,
                 "remoteShell",
-                {"pelix.shell.address": "127.0.0.1", "pelix.shell.port": 9001},
+                {"pelix.shell.address": "127.0.0.1", "pelix.shell.port": 0},
             )
 
     def tearDown(self) -> None:

--- a/tests/shell/test_remote_tls.py
+++ b/tests/shell/test_remote_tls.py
@@ -10,6 +10,7 @@ import importlib.util
 import ipaddress
 import os
 import pathlib
+import re
 import socket
 import sys
 import tempfile
@@ -390,8 +391,7 @@ else:
 
             ps1 = pelix.shell.core._ShellService.PS1
 
-            # Start the remote shell process
-            port = 9001
+            # Start the remote shell process, on a random port
             args = [sys.executable, "-m"]
             if has_coverage:
                 args += ["coverage", "run", "-m"]
@@ -400,7 +400,7 @@ else:
                 "-a",
                 "127.0.0.1",
                 "-p",
-                str(port),
+                "0",
                 "--cert",
                 srv_cert,
                 "--key",
@@ -414,9 +414,26 @@ else:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
+            assert process.stderr is not None
 
-            # Wait a little to ensure that the socket is here
-            time.sleep(1)
+            # Wait for the interactive console banner to report the bound port
+            # (see pelix.shell.remote.main(): interact() writes it to stderr)
+            # The trailing "\n" ensures the whole number was read, not just its first digit
+            port_re = re.compile(r"Remote shell bound to: [^:\n]+:(\d+)\n")
+            port = None
+            got = ""
+            banner_timer = threading.Timer(10, process.terminate)
+            banner_timer.start()
+            while port is None:
+                char = to_str(process.stderr.read(1))
+                if not char:
+                    output = to_str(process.stderr.read())
+                    self.fail(f"Process exited before printing its port (rc={process.returncode})\n{output}")
+                got += char
+                match = port_re.search(got)
+                if match:
+                    port = int(match.group(1))
+            banner_timer.cancel()
 
             # Check if the remote shell port has been opened
             client = TLSShellClient(ps1, self.fail, client_cert, client_key, ca_chain)
@@ -522,7 +539,7 @@ class TLSRemoteShellTest(unittest.TestCase):
                     "remoteShell",
                     {
                         "pelix.shell.address": "127.0.0.1",
-                        "pelix.shell.port": 9001,
+                        "pelix.shell.port": 0,
                         "pelix.shell.ssl.ca": ca_chain,
                         "pelix.shell.ssl.cert": srv_cert,
                         "pelix.shell.ssl.key": srv_key,
@@ -567,7 +584,7 @@ class TLSRemoteShellTest(unittest.TestCase):
                     "remoteShell",
                     {
                         "pelix.shell.address": "127.0.0.1",
-                        "pelix.shell.port": 9001,
+                        "pelix.shell.port": 0,
                         "pelix.shell.ssl.ca": ca_chain,
                         "pelix.shell.ssl.cert": srv_cert,
                         "pelix.shell.ssl.key": srv_key,
@@ -604,7 +621,7 @@ class TLSRemoteShellTest(unittest.TestCase):
                     "remoteShell",
                     {
                         "pelix.shell.address": "127.0.0.1",
-                        "pelix.shell.port": 9001,
+                        "pelix.shell.port": 0,
                         "pelix.shell.ssl.ca": ca_chain,
                         "pelix.shell.ssl.cert": srv_cert,
                         "pelix.shell.ssl.key": srv_key,


### PR DESCRIPTION
- Avoid using fixed ports (avoids local run conflicts)
- MQTT discovery: clean session when client ID is not set