### PR TITLE
Certificates handling

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -136,9 +136,13 @@ If you are deploying iPOPO in production, and particularly on a network you do n
 - **Do not expose the remote shell.**
   It allows installing, starting and stopping arbitrary bundles, which is equivalent to remote code execution.
   It binds to `localhost` by default, keep it that way.
-  If remote administration is required, use the TLS front-end **with certificate-based client authentication** (`pelix.shell.ssl.ca`), documented in `docs/refcards/shell.md`, and restrict it to an administrative network
+  If remote administration is required, use the TLS front-end **with certificate-based client authentication** (`pelix.shell.ssl.ca`), documented in `docs/refcards/shell.md`, and restrict it to an administrative network.
+  `pelix.shell.ssl.ca` is **not optional**: setting `pelix.shell.ssl.cert` without it makes the shell accept any client certificate signed by any authority of the system trust store.
+  Since 3.2.2 this is logged as an error; it will be refused in 3.3.0
 - **Enable TLS verification on the XMPP client.**
-  Pass `ssl_verify=True`; the current default does not verify server certificates
+  Set the `shell.xmpp.tls.verify` property of the XMPP shell to `1`, or pass `--tls-verify` to `python -m pelix.shell.xmpp`.
+  When using `pelix.misc.xmpp` directly, pass `ssl_verify=True`.
+  The default does not verify server certificates; it will become `1` in 3.3.0
 - **Keep Remote Services and mDNS discovery on trusted network segments only.**
   mDNS discovery accepts input from any host on the local link
 - **Validate any externally-derived Configuration Admin PID** before passing it to the Configuration Admin API

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -107,6 +107,9 @@ All versions up to 3.2.1 are affected.
 * Added tests for the code shared by the HTTP service implementations
 * Python 3.15 is now tested in CI, except for RSA which has some dependencies
   not yet available pre-built for that version
+* Added tests for the TLS configuration of the remote and XMPP shells
+* The MQTT service and EventAdmin MQTT bridge tests are now skipped when no
+  broker is available
 
 ## iPOPO 3.2.1
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,23 @@ All versions up to 3.2.1 are affected.
   discovery providers, and have no use for a DTD.
   Recent versions of `expat` limit that expansion, but Pelix also supports
   systems where it is not the case
+* The remote shell now logs an error when `pelix.shell.ssl.cert` is set without
+  `pelix.shell.ssl.ca`.
+  In that case, the shell requires a client certificate but validates it against
+  the system trust store, meaning any certificate signed by any publicly trusted
+  authority is accepted.
+  The configuration is only reported in this release, to avoid breaking existing
+  deployments in a patch version: **it will be refused in iPOPO 3.3.0**
+* The XMPP shell can now verify the certificate of the XMPP server, with the new
+  `shell.xmpp.tls.verify` property (or the `--tls-verify` argument of
+  `python -m pelix.shell.xmpp`).
+  The XMPP shell is a full remote administration channel, but it gave no way to
+  follow the hardening guidance of `SECURITY.md`: it always used the
+  `ssl_verify=False` default of `pelix.misc.xmpp`, so an attacker able to
+  intercept the connection could impersonate the server and capture the
+  credentials.
+  The property **defaults to `0`**, keeping the previous behaviour in a patch
+  version: **it will default to `1` in iPOPO 3.3.0**
 
 ### Utilities
 

--- a/docs/refcards/shell.md
+++ b/docs/refcards/shell.md
@@ -136,6 +136,18 @@ This factory accepts the following properties:
 | `pelix.shell.ssl.key` | `None` | Path to the server's private key |
 | `pelix.shell.ssl.key_password` | `None` | Password of the server's private key |
 
+:::{warning}
+`pelix.shell.ssl.ca` is not optional when `pelix.shell.ssl.cert` is set.
+
+When a certificate is given without an authority chain, the remote shell still
+requires a client certificate, but validates it against the **system trust
+store**: any certificate signed by any publicly trusted authority is accepted,
+by a shell which can install and start arbitrary bundles.
+
+iPOPO 3.2.2 logs an error when it detects this configuration, but still starts.
+Starting with iPOPO 3.3.0, this configuration will be refused.
+:::
+
 ### XMPP Shell
 
 The XMPP shell interface allows to communicate with a Pelix framework
@@ -167,6 +179,7 @@ In addition to the common parameters, the script accepts the following ones:
 | `-p PORT`, `--port PORT` | 5222 | Port of the XMPP server |
 | `--tls` | *not set* | If set, use a STARTTLS connection |
 | `--ssl` | *not set* | If set, use an SSL connection |
+| `--tls-verify` | *not set* | If set, verify the certificate of the XMPP server |
 
 #### Programmatic startup
 
@@ -192,6 +205,16 @@ This factory accepts the following properties:
 | `shell.xmpp.password` | `None`    | User password             |
 | `shell.xmpp.tls`      | 1         | Use a STARTTLS connection |
 | `shell.xmpp.ssl`      | 0         | Use an SSL connection     |
+| `shell.xmpp.tls.verify` | 0       | Verify the certificate of the XMPP server |
+
+:::{warning}
+`shell.xmpp.tls.verify` defaults to `0`, meaning the certificate of the XMPP
+server is **not** verified: an attacker able to intercept the connection can
+impersonate the server and capture the credentials of the shell account.
+
+Set it to `1` in any deployment where the connection to the server is not fully
+trusted. This default will become `1` in iPOPO 3.3.0.
+:::
 
 ## Provided command bundles
 

--- a/pelix/shell/remote.py
+++ b/pelix/shell/remote.py
@@ -35,7 +35,7 @@ import socketserver
 import sys
 import threading
 from select import select
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pelix.framework
 import pelix.ipv6utils
@@ -54,14 +54,22 @@ from pelix.ipopo.decorators import (
 from pelix.shell import beans
 from pelix.shell.console import handle_common_arguments, make_common_parser
 
-try:
-    # Some Python distributions don't support SSL
+if TYPE_CHECKING:
+    # Type checkers must always see "ssl" as the module and never as None, so
+    # that annotations like "ssl.SSLContext" stay valid. Whether SSL is really
+    # available is a run-time question, answered by HAS_SSL.
     import ssl
 
-    HAS_SSL = True
-except ImportError:
-    HAS_SSL = False
-    ssl = None  # ty: ignore[invalid-assignment]
+    HAS_SSL: bool = True
+else:
+    try:
+        # Some Python distributions don't support SSL
+        import ssl
+
+        HAS_SSL = True
+    except ImportError:
+        HAS_SSL = False
+        ssl = None
 
 # ------------------------------------------------------------------------------
 
@@ -279,6 +287,10 @@ class ThreadingTCPServerFamily(socketserver.ThreadingTCPServer):
         self.key_password = key_password
         self.ca_file = ca_file
 
+        # Prepare the SSL context once: the certificate and key files must not
+        # be re-read and re-parsed for each incoming connection
+        self.ssl_context: ssl.SSLContext | None = self.__make_ssl_context()
+
         # Call the super constructor
         socketserver.ThreadingTCPServer.__init__(self, server_address, request_handler_class, False)
         if self.address_family == socket.AF_INET6:
@@ -290,6 +302,43 @@ class ThreadingTCPServerFamily(socketserver.ThreadingTCPServer):
             except OSError:
                 _logger.exception("Error setting up IPv6 double stack")
 
+    def __make_ssl_context(self) -> "ssl.SSLContext | None":
+        """
+        Prepares the SSL context to accept clients with a certificate signed by
+        a known chain of authority. Other clients will be rejected during the
+        handshake.
+
+        :return: The SSL context, or None if TLS is not configured
+        """
+        if not HAS_SSL or not self.cert_file:
+            # Nothing to do
+            return None
+
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        try:
+            # Force a valid/signed client-side certificate
+            context.verify_mode = ssl.CERT_REQUIRED
+
+            # Load the server certificate
+            context.load_cert_chain(
+                certfile=self.cert_file,
+                keyfile=self.key_file,
+                password=self.key_password,
+            )
+
+            if self.ca_file:
+                # Load the given authority chain
+                context.load_verify_locations(self.ca_file)
+            else:
+                # Load the default chain if none given
+                context.load_default_certs(ssl.Purpose.CLIENT_AUTH)
+        except Exception as ex:
+            # Explicitly log the error as the default behaviour hides it
+            _logger.error("Error setting up the SSL context: %s", ex)
+            raise
+
+        return context
+
     def get_request(self) -> tuple[socket.socket, tuple[str, int]]:
         """
         Accepts a new client. Sets up SSL wrapping if necessary.
@@ -299,36 +348,12 @@ class ThreadingTCPServerFamily(socketserver.ThreadingTCPServer):
         # Accept the client
         client_socket, client_address = self.socket.accept()
 
-        if ssl is not None and self.cert_file:
-            # Setup an SSL context to accept clients with a certificate
-            # signed by a known chain of authority.
-            # Other clients will be rejected during handshake.
-            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-            try:
-                # Force a valid/signed client-side certificate
-                context.verify_mode = ssl.CERT_REQUIRED
-
-                # Load the server certificate
-                context.load_cert_chain(
-                    certfile=self.cert_file,
-                    keyfile=self.key_file,
-                    password=self.key_password,
-                )
-
-                if self.ca_file:
-                    # Load the given authority chain
-                    context.load_verify_locations(self.ca_file)
-                else:
-                    # Load the default chain if none given
-                    context.load_default_certs(ssl.Purpose.CLIENT_AUTH)
-            except Exception as ex:
-                # Explicitly log the error as the default behaviour hides it
-                _logger.error("Error setting up the SSL context: %s", ex)
-                raise
-
+        if self.ssl_context is not None:
             try:
                 # SSL handshake
-                client_stream = cast(socket.socket, context.wrap_socket(client_socket, server_side=True))
+                client_stream = cast(
+                    socket.socket, self.ssl_context.wrap_socket(client_socket, server_side=True)
+                )
             except ssl.SSLError as ex:
                 # Explicitly log the exception before re-raising it
                 _logger.warning("Error during SSL handshake with %s: %s", client_address, ex)
@@ -517,6 +542,16 @@ class IPopoRemoteShell(pelix.shell.RemoteShell):
         if not self._encoding:
             self._encoding = "utf-8"
 
+        if self._cert_file and not self._ca_file:
+            # Without an explicit authority chain, any client certificate signed
+            # by any CA of the system trust store would be accepted
+            _logger.error(
+                "pelix.shell.ssl.cert is set without pelix.shell.ssl.ca: ANY client certificate "
+                "signed by ANY CA in the system trust store will be accepted by a shell which can "
+                "install and start arbitrary bundles. Set pelix.shell.ssl.ca. "
+                "This configuration will be refused in iPOPO 3.3.0."
+            )
+
         # Start the TCP server
         self._thread, self._server, self._server_flag = _create_server(
             self,
@@ -595,7 +630,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="pelix.shell.remote",
         parents=[make_common_parser()],
-        description=f"Pelix Remote Shell ({'with' if ssl is not None else 'without'} SSL support)",
+        description=f"Pelix Remote Shell ({'with' if HAS_SSL else 'without'} SSL support)",
     )
 
     # Remote shell options
@@ -614,7 +649,7 @@ def main(argv: list[str] | None = None) -> int:
         help="The remote shell binding port",
     )
 
-    if ssl is not None:
+    if HAS_SSL:
         # Remote Shell TLS options
         group = parser.add_argument_group("TLS Options")
         group.add_argument("--cert", help="Path to the server certificate file")
@@ -669,7 +704,7 @@ def main(argv: list[str] | None = None) -> int:
             ipopo.get_instance_details(rshell_name)
         except ValueError:
             # Component doesn't exist, we can instantiate it.
-            if ssl is not None:
+            if HAS_SSL:
                 # Copy parsed arguments
                 ca_chain = args.ca_chain
                 cert = args.cert

--- a/pelix/shell/xmpp.py
+++ b/pelix/shell/xmpp.py
@@ -154,6 +154,7 @@ class _XmppInStream(IO[str]):
 @HiddenProperty("_password", "shell.xmpp.password")
 @Property("_use_tls", "shell.xmpp.tls", "1")
 @Property("_use_ssl", "shell.xmpp.ssl", "0")
+@Property("_tls_verify", "shell.xmpp.tls.verify", "0")
 class IPopoXMPPShell:
     """
     The iPOPO XMPP Shell, based on the Pelix Shell
@@ -172,6 +173,7 @@ class IPopoXMPPShell:
         self._password: str | None = None
         self._use_tls: bool = True
         self._use_ssl: bool = False
+        self._tls_verify: bool = False
 
         # XMPP Bot
         self.__bot: pelix.misc.xmpp.BasicBot | None = None
@@ -204,6 +206,7 @@ class IPopoXMPPShell:
         self._port = self.__normalize_int(self._port, 5222)
         self._use_tls = bool(self.__normalize_int(self._use_tls, 1))
         self._use_ssl = bool(self.__normalize_int(self._use_ssl, 0))
+        self._tls_verify = bool(self.__normalize_int(self._tls_verify, 0))
 
         # Check other values
         if not self._host:
@@ -228,7 +231,7 @@ class IPopoXMPPShell:
         )
 
         # Create the bot. Negative priority avoids listening to human messages
-        self.__bot = pelix.misc.xmpp.BasicBot(self._jid, self._password)
+        self.__bot = pelix.misc.xmpp.BasicBot(self._jid, self._password, ssl_verify=self._tls_verify)
         self.__bot.auto_authorize = True
 
         # Register to events
@@ -421,6 +424,12 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Use an SSL connection",
     )
+    group.add_argument(
+        "--tls-verify",
+        dest="tls_verify",
+        action="store_true",
+        help="Verify the certificate of the XMPP server",
+    )
 
     # Parse them
     args = parser.parse_args(argv)
@@ -480,6 +489,7 @@ def main(argv: list[str] | None = None) -> int:
                 "shell.xmpp.password": password,
                 "shell.xmpp.tls": args.use_tls,
                 "shell.xmpp.ssl": args.use_ssl,
+                "shell.xmpp.tls.verify": args.tls_verify,
             },
         )
 

--- a/tests/services/test_eventadmin_mqtt.py
+++ b/tests/services/test_eventadmin_mqtt.py
@@ -28,6 +28,10 @@ except ImportError:
 __version_info__ = (3, 2, 2)
 __version__ = ".".join(str(x) for x in __version_info__)
 
+MQTT_SERVER = find_mqtt_server()
+if not MQTT_SERVER:
+    raise unittest.SkipTest("No valid MQTT server found")
+
 # ------------------------------------------------------------------------------
 
 
@@ -152,7 +156,7 @@ class EventAdminMqttBridgeTest(unittest.TestCase):
     Tests the EventAdmin MQTT bridge service
     """
 
-    HOST = find_mqtt_server()
+    HOST = MQTT_SERVER
     PORT = 1883
 
     framework: pelix.framework.Framework
@@ -256,7 +260,6 @@ class EventAdminMqttBridgeTest(unittest.TestCase):
         bridge_event_filter = "/mqtt/propagate/*"
 
         # Setup a client
-        assert self.HOST is not None
         client = MQTTListener(self.HOST, self.PORT, bridge_prefix)
         client.start()
         if not client.connect_event.wait(10):
@@ -305,7 +308,6 @@ class EventAdminMqttBridgeTest(unittest.TestCase):
         bridge_event_filter = "/mqtt/propagate/*"
 
         # Setup a client
-        assert self.HOST is not None
         client = MQTTListener(self.HOST, self.PORT, bridge_prefix)
         client.start()
         if not client.connect_event.wait(10):
@@ -392,7 +394,6 @@ class EventAdminMqttBridgeTest(unittest.TestCase):
         self._setup_bridge(bridge_event_filter, bridge_prefix)
 
         # Setup a client
-        assert self.HOST is not None
         client = MQTTListener(self.HOST, self.PORT, bridge_prefix)
         client.start()
         if not client.connect_event.wait(10):

--- a/tests/services/test_mqtt.py
+++ b/tests/services/test_mqtt.py
@@ -29,6 +29,10 @@ except ImportError:
 __version_info__ = (3, 2, 2)
 __version__ = ".".join(str(x) for x in __version_info__)
 
+MQTT_SERVER = find_mqtt_server()
+if not MQTT_SERVER:
+    raise unittest.SkipTest("No valid MQTT server found")
+
 # ------------------------------------------------------------------------------
 
 
@@ -55,7 +59,7 @@ class MqttServiceTest(unittest.TestCase):
     Tests the MQTT utility service
     """
 
-    HOST = find_mqtt_server()
+    HOST = MQTT_SERVER
     PORT = 1883
 
     framework: pelix.framework.Framework

--- a/tests/shell/test_remote_tls.py
+++ b/tests/shell/test_remote_tls.py
@@ -18,7 +18,7 @@ import threading
 import time
 import unittest
 from collections.abc import Callable
-from typing import cast
+from typing import Any, cast
 
 try:
     import ssl
@@ -642,6 +642,104 @@ class TLSRemoteShellTest(unittest.TestCase):
         finally:
             # Close the client in any case
             client.close()
+
+    def test_missing_ca_warns_but_starts(self) -> None:
+        """
+        Tests that a certificate without an authority chain is accepted, but
+        warned about: without a CA file, any client certificate signed by any
+        CA of the system trust store would be accepted.
+        """
+        srv_cert = os.path.join(TMP_DIR, "server.crt")
+        srv_key = os.path.join(TMP_DIR, "server.key")
+
+        # Start the remote shell without a CA file
+        context = self.framework.get_bundle_context()
+        with (
+            self.assertLogs("pelix.shell.remote", level="ERROR") as logs,
+            use_ipopo(context) as ipopo,
+        ):
+            self.remote = cast(
+                RemoteShell,
+                ipopo.instantiate(
+                    FACTORY_REMOTE_SHELL,
+                    "remoteShell",
+                    {
+                        "pelix.shell.address": "127.0.0.1",
+                        "pelix.shell.port": 0,
+                        "pelix.shell.ssl.cert": srv_cert,
+                        "pelix.shell.ssl.key": srv_key,
+                    },
+                ),
+            )
+
+        # The warning must name the property to set
+        self.assertIn("pelix.shell.ssl.ca", "\n".join(logs.output))
+
+        # ... but the shell must still be running (this is to change in 3.3.0)
+        _, port = self.remote.get_access()
+        assert port is not None
+        self.assertGreater(port, 0)
+
+    def test_ssl_context_is_reused(self) -> None:
+        """
+        Tests that the SSL context is prepared once, not rebuilt for each client
+        """
+        ca_chain = os.path.join(TMP_DIR, "ca.crt")
+        srv_cert = os.path.join(TMP_DIR, "server.crt")
+        srv_key = os.path.join(TMP_DIR, "server.key")
+        client_cert = os.path.join(TMP_DIR, "client.crt")
+        client_key = os.path.join(TMP_DIR, "client.key")
+
+        # Start the remote shell
+        context = self.framework.get_bundle_context()
+        with use_ipopo(context) as ipopo:
+            self.remote = cast(
+                RemoteShell,
+                ipopo.instantiate(
+                    FACTORY_REMOTE_SHELL,
+                    "remoteShell",
+                    {
+                        "pelix.shell.address": "127.0.0.1",
+                        "pelix.shell.port": 0,
+                        "pelix.shell.ssl.ca": ca_chain,
+                        "pelix.shell.ssl.cert": srv_cert,
+                        "pelix.shell.ssl.key": srv_key,
+                    },
+                ),
+            )
+
+        # The context must have been prepared before any client showed up
+        server = cast(Any, self.remote)._server
+        ssl_context = server.ssl_context
+        self.assertIsNotNone(ssl_context)
+
+        # Two successive clients must be served by that very same context
+        for _ in range(2):
+            client = TLSShellClient(self.shell.get_ps1(), self.fail, client_cert, client_key, ca_chain)
+            try:
+                client.connect(self.remote.get_access())  # type: ignore
+                self.assertEqual(client.run_command("echo toto"), "toto")
+            finally:
+                client.close()
+
+            self.assertIs(server.ssl_context, ssl_context)
+
+    def test_no_ssl_context_without_certificate(self) -> None:
+        """
+        Tests that no SSL context is prepared when no certificate is given
+        """
+        context = self.framework.get_bundle_context()
+        with use_ipopo(context) as ipopo:
+            self.remote = cast(
+                RemoteShell,
+                ipopo.instantiate(
+                    FACTORY_REMOTE_SHELL,
+                    "remoteShell",
+                    {"pelix.shell.address": "127.0.0.1", "pelix.shell.port": 0},
+                ),
+            )
+
+        self.assertIsNone(cast(Any, self.remote)._server.ssl_context)
 
 
 if __name__ == "__main__":

--- a/tests/shell/test_xmpp_config.py
+++ b/tests/shell/test_xmpp_config.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests the configuration of the XMPP shell interface.
+
+Unlike test_xmpp.py, this module doesn't need a live XMPP server: the bot is
+replaced by a recording stub, so the wiring of the component properties can be
+checked anywhere.
+
+:author: Thomas Calmant
+"""
+
+import unittest
+from typing import Any
+from unittest import mock
+
+try:
+    import pelix.misc.xmpp
+    import pelix.shell.xmpp
+except ImportError:
+    # Missing requirement: not a fatal error
+    raise unittest.SkipTest("XMPP client dependency missing: skip test")
+
+from pelix.framework import FrameworkFactory
+from pelix.ipopo.constants import use_ipopo
+from pelix.shell import FACTORY_XMPP_SHELL
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# ------------------------------------------------------------------------------
+
+
+class _FakeBot:
+    """
+    Records how the bot was constructed and swallows everything else
+    """
+
+    def __init__(self, jid: Any, password: Any, **kwargs: Any) -> None:
+        self.jid = jid
+        self.password = password
+        self.kwargs = kwargs
+        self.auto_authorize: bool = False
+
+    def add_event_handler(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def connect(self, *_: Any, **__: Any) -> bool:
+        return True
+
+    def disconnect(self, *_: Any, **__: Any) -> None:
+        pass
+
+
+class XMPPShellConfigTest(unittest.TestCase):
+    """
+    Tests the properties of the XMPP shell component
+    """
+
+    def setUp(self) -> None:
+        """
+        Starts a framework with the XMPP shell bundle
+        """
+        self.framework = FrameworkFactory.get_framework()
+        self.addCleanup(FrameworkFactory.delete_framework)
+        self.framework.start()
+        self.context = self.framework.get_bundle_context()
+
+        self.context.install_bundle("pelix.ipopo.core").start()
+        self.context.install_bundle("pelix.shell.core").start()
+        self.context.install_bundle("pelix.shell.xmpp").start()
+
+    def instantiate(self, properties: dict[str, Any]) -> _FakeBot:
+        """
+        Instantiates the XMPP shell with the given properties and returns the
+        stub bot it created
+
+        :param properties: Component properties
+        :return: The recording bot stub
+        """
+        props: dict[str, Any] = {
+            "shell.xmpp.jid": "bot@localhost",
+            "shell.xmpp.password": "foobar",
+        }
+        props.update(properties)
+
+        with (
+            mock.patch.object(pelix.misc.xmpp, "BasicBot", _FakeBot),
+            use_ipopo(self.context) as ipopo,
+        ):
+            component = ipopo.instantiate(FACTORY_XMPP_SHELL, "xmpp-shell", props)
+
+        # Name-mangled private attribute of IPopoXMPPShell
+        bot = component._IPopoXMPPShell__bot  # type: ignore[attr-defined]
+        assert isinstance(bot, _FakeBot)
+        return bot
+
+    def test_tls_verify_disabled_by_default(self) -> None:
+        """
+        The certificate of the server is not verified by default (3.2.x)
+        """
+        bot = self.instantiate({})
+        self.assertFalse(bot.kwargs["ssl_verify"])
+
+    def test_tls_verify_enabled(self) -> None:
+        """
+        The shell.xmpp.tls.verify property reaches the bot
+        """
+        bot = self.instantiate({"shell.xmpp.tls.verify": "1"})
+        self.assertTrue(bot.kwargs["ssl_verify"])
+
+    def test_tls_verify_explicitly_disabled(self) -> None:
+        """
+        The shell.xmpp.tls.verify property can be set to 0 explicitly
+        """
+        bot = self.instantiate({"shell.xmpp.tls.verify": "0"})
+        self.assertFalse(bot.kwargs["ssl_verify"])
+
+    def test_tls_verify_invalid_value(self) -> None:
+        """
+        An unparsable value falls back to the default (no verification)
+        """
+        bot = self.instantiate({"shell.xmpp.tls.verify": "yes please"})
+        self.assertFalse(bot.kwargs["ssl_verify"])
+
+
+# ------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Added option to XMPP shell to verify TLS certificates
- Log an error when no CA is provided to the TLS remote shell to check client certificates. This will be rejected in 3.3