### PR TITLE
Change type ignore comment

### DIFF
--- a/pelix/shell/completion/pelix.py
+++ b/pelix/shell/completion/pelix.py
@@ -38,7 +38,7 @@ from .core import AbstractCompleter
 try:
     import readline
 except ImportError:
-    readline = None  # ty: ignore[invalid-assignment]
+    readline = None  # type: ignore
 
 if TYPE_CHECKING:
     from pelix.framework import BundleContext


### PR DESCRIPTION
No error on the lint check command locally with both versions of the comment ; failure when removing ti.