### PR TITLE
Added ConfigurationAdmin instantiation support in iPOPO

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## iPOPO 3.2.3
+## iPOPO 3.x.x
 
 :::{admonition} Release Date
 :class: info
@@ -19,6 +19,34 @@ Unreleased
   code importing the generated modules directly, which is not expected outside
   of the provider itself
 * The generated code now requires a `protobuf` runtime 6.33.2 or newer
+
+### iPOPO
+
+* Components can now be managed by ConfigurationAdmin, with the new
+  `pelix.ipopo.configadmin` bundle
+  ([#112](https://github.com/tcalmant/ipopo/issues/112)):
+* Added `IPopoService.reconfigure(name, properties)`, to update the properties
+  of a running component from the outside.
+* Added `IPopoWaitingList.update(component, properties, removed)`, to change the
+  properties of a component of the waiting list.
+* Added `IPopoService.get_instance_properties(name)`, which returns the
+  properties of a component with their real value, where
+  `get_instance_details(name)` converts them to their string representation
+* The iPOPO waiting list no longer holds its lock while instantiating, killing
+  or reconfiguring a component: the callbacks of a component can call back into
+  the waiting list from another thread
+
+### Services
+
+* Fixed a deadlock in FileInstall: the notification of a folder listener could
+  block the invalidation of the service
+* Fixed a deadlock in ConfigurationAdmin during the update and the deletion of
+  a configuration.
+
+### Tests
+
+* Added tests for the configuration of ConfigurationAdmin managed service
+  factories
 
 ## iPOPO 3.2.2
 

--- a/docs/refcards/configadmin.rst
+++ b/docs/refcards/configadmin.rst
@@ -25,6 +25,9 @@ Two kinds of managed services exist:
    `chapter 104 <https://docs.osgi.org/specification/osgi.cmpn/8.1.0/service.cm.html>`_
    of the OSGi Compendium Services Specification.
 
+.. note:: iPOPO components can be created, configured and killed from
+   ConfigurationAdmin: see :ref:`ipopo_configadmin`.
+
 .. note:: This page is highly inspired from the
    `Configuration Admin tutorial <https://web.archive.org/web/20200229033154/http://felix.apache.org/documentation/subprojects/apache-felix-config-admin.html>`_
    from the `Apache Felix project <https://felix.apache.org/documentation/index.html>`_.

--- a/docs/refcards/index.md
+++ b/docs/refcards/index.md
@@ -10,6 +10,7 @@ bundles
 services
 ipopo
 ipopo_decorators
+ipopo_configadmin
 init_config
 log
 http

--- a/docs/refcards/ipopo_configadmin.rst
+++ b/docs/refcards/ipopo_configadmin.rst
@@ -1,0 +1,227 @@
+.. _ipopo_configadmin:
+
+.. module:: pelix.ipopo.configadmin
+
+Components and Configuration Admin
+##################################
+
+Concept
+=======
+
+The ``pelix.ipopo.configadmin`` bundle bridges :ref:`configadmin` and iPOPO:
+it lets an administrator manage a composition at runtime, without writing any
+code and without restarting the framework.
+
+It provides three mechanisms:
+
+* a *factory configuration* describes a component instance: creating it
+  instantiates the component, updating it reconfigures the component, and
+  deleting it kills the component;
+* a component which declares a ``service.pid`` property gets the entries of
+  the configuration with that PID injected in its properties;
+* a component whose factory uses the :class:`~pelix.ipopo.decorators.RequiresConfiguration`
+  decorator waits for its configuration before being validated.
+
+This is the counterpart of the ``configuration-policy`` attribute and of the
+factory configurations described in the
+`chapter 112 <https://docs.osgi.org/specification/osgi.cmpn/8.1.0/service.component.html>`_
+of the OSGi Compendium Services Specification, adapted to iPOPO: there is no
+callback receiving a configuration dictionary, the entries of a configuration
+are simply mapped onto the *properties* of the component.
+
+.. note:: A configuration entry which is only read when the component is
+   created, like ``requires.filters`` or ``temporal.timeouts``, keeps its
+   initial value when the configuration is updated. Use the ``restart``
+   update policy described below to take those into account.
+
+.. note:: A property declared with ``@HiddenProperty`` never becomes public: a
+   configuration entry of the same name is ignored. To update it
+   confidentially, e.g. to rotate a password, prefix its name with a dot
+   (``.password`` updates the ``password`` property).
+
+.. note:: ``service.pid``, ``service.factoryPid`` and ``service.bundleLocation``
+   are added by ConfigurationAdmin, not the administrator, and are never
+   treated as component properties to remove: a component keeps its PID even
+   after its configuration is deleted.
+
+
+Setting up
+==========
+
+The bridge requires the ConfigurationAdmin service and the iPOPO waiting list.
+The handler of the ``@RequiresConfiguration`` decorator lives in its own
+bundle, which must be installed for the components of a decorated factory to
+be instantiated.
+
+.. code-block:: python
+
+   framework = create_framework(
+       (
+           "pelix.ipopo.core",
+           "pelix.ipopo.waiting",
+           "pelix.ipopo.handlers.configadmin",
+           "pelix.services.configadmin",
+           "pelix.ipopo.configadmin",
+       )
+   )
+
+
+Creating components from configurations
+=======================================
+
+The bridge handles the factory configurations of the
+``pelix.ipopo.component`` PID
+(:py:const:`pelix.ipopo.constants.IPOPO_CONFIGADMIN_FACTORY_PID`).
+Each of those configurations describes one component instance and recognises
+the following entries:
+
++--------------------------+--------------------------------------------------+
+| Entry                    | Description                                      |
++==========================+==================================================+
+| ``ipopo.factory.name``   | Name of the iPOPO factory to instantiate.        |
+|                          | Mandatory: a configuration without it is ignored |
++--------------------------+--------------------------------------------------+
+| ``instance.name``        | Name of the component instance. Defaults to the  |
+|                          | PID of the configuration                         |
++--------------------------+--------------------------------------------------+
+| ``ipopo.update.policy``  | Either ``reconfigure`` (default), to update the  |
+|                          | properties of the live component, or ``restart``,|
+|                          | to kill it and instantiate it again              |
++--------------------------+--------------------------------------------------+
+
+Only ``ipopo.factory.name`` and ``ipopo.update.policy`` are consumed by the
+bridge: every other entry, including ``instance.name`` and the
+``service.pid``/``service.factoryPid`` entries added by ConfigurationAdmin,
+becomes a property of the component.
+
+Here is a session with the Pelix shell, using the commands of the
+``pelix.shell.configadmin`` and ``pelix.shell.ipopo`` bundles:
+
+.. code-block:: text
+
+   $ config.create pelix.ipopo.component ipopo.factory.name=hello-factory \
+         instance.name=hello name=world
+   New configuration: pelix.ipopo.component-3d5b0f6e-...
+   $ instances
+   +-------+---------------+-------+
+   | Name  | Factory       | State |
+   +=======+===============+=======+
+   | hello | hello-factory | VALID |
+   +-------+---------------+-------+
+   $ config.update pelix.ipopo.component-3d5b0f6e-... name=pelix
+   $ config.delete pelix.ipopo.component-3d5b0f6e-...
+
+The same can be done programmatically:
+
+.. code-block:: python
+
+   from pelix.ipopo.constants import (
+       IPOPO_CONFIG_FACTORY_NAME,
+       IPOPO_CONFIGADMIN_FACTORY_PID,
+       IPOPO_INSTANCE_NAME,
+   )
+
+   config = config_admin.create_factory_configuration(IPOPO_CONFIGADMIN_FACTORY_PID)
+   config.update(
+       {
+           IPOPO_CONFIG_FACTORY_NAME: "hello-factory",
+           IPOPO_INSTANCE_NAME: "hello",
+           "name": "world",
+       }
+   )
+
+Components go through the :ref:`iPOPO waiting list <refcard_component>`: a
+configuration naming a factory which isn't registered yet is honoured as soon
+as it appears, and again if its bundle is stopped then started. With the
+default JSON storage, configurations are persistent: the components they
+describe come back the next time the framework starts. Stopping the
+``pelix.ipopo.configadmin`` bundle kills the components it created.
+
+.. note:: A property removed from a configuration goes back to the value
+   declared by the factory with ``@Property``, or to ``None`` if the factory
+   doesn't declare it.
+
+
+Configuring existing components
+===============================
+
+A component which declares a ``service.pid`` property, whatever the way it has
+been instantiated, follows the configuration with that PID: its entries are
+injected in the properties of the component when the configuration is updated,
+and the properties go back to their declared value when it is deleted.
+
+.. code-block:: python
+
+   from pelix.constants import SERVICE_PID
+   from pelix.ipopo.decorators import ComponentFactory, Instantiate, Property
+
+   @ComponentFactory()
+   @Property("_name", "name", "world")
+   @Property("_pid", SERVICE_PID, "sample.hello")
+   @Instantiate("hello")
+   class Hello:
+       ...
+
+Components created from a factory configuration, components using the
+``@RequiresConfiguration`` decorator and components providing a managed
+service are left alone: they already follow their own configuration.
+
+.. note:: Here also, a property removed from the configuration goes back to
+   the value declared by the factory with ``@Property``, not to the value it
+   was given when the component was instantiated. Use ``@RequiresConfiguration``
+   when the component must recover its instantiation values.
+
+.. warning:: Nothing delays the validation of such a component: it is
+   validated with the values declared by its factory, then reconfigured once
+   the configuration reaches it. Use ``@RequiresConfiguration`` when the
+   component must not run without its configuration.
+
+
+Waiting for a configuration
+===========================
+
+The ``@RequiresConfiguration`` decorator binds the components of a factory to
+a configuration and, unless the requirement is declared optional, keeps them
+invalid as long as no configuration is available.
+
+.. code-block:: python
+
+   from pelix.ipopo.decorators import (
+       ComponentFactory, Instantiate, Property, RequiresConfiguration, Validate
+   )
+
+   @ComponentFactory()
+   @Property("_name", "name", "world")
+   @RequiresConfiguration("sample.hello")
+   @Instantiate("hello")
+   class Hello:
+       @Validate
+       def validate(self, context):
+           # Called only once the "sample.hello" configuration exists:
+           # self._name holds the value it gives
+           print("Hello,", self._name)
+
+The PID can be omitted, in which case the ``service.pid`` property of the
+component is used. This allows several instances of the same factory to follow
+different configurations:
+
+.. code-block:: python
+
+   @ComponentFactory("hello-factory")
+   @Property("_name", "name", "world")
+   @Property("_pid", SERVICE_PID)
+   @RequiresConfiguration()
+   class Hello:
+       ...
+
+   # Then, in a configuration or in an initialization file:
+   #   instance.name=hello-fr, service.pid=sample.hello.fr
+
+The ``update_policy`` argument tells what happens when the configuration of a
+running component is updated: ``reconfigure`` (default) updates its properties
+in place, ``restart`` invalidates the component before applying them, so that
+the ``@Validate`` callback is called again.
+
+.. autoclass:: pelix.ipopo.decorators.RequiresConfiguration
+   :members:
+   :noindex:

--- a/docs/refcards/ipopo_decorators.rst
+++ b/docs/refcards/ipopo_decorators.rst
@@ -68,6 +68,7 @@ Requirements
 .. autoclass:: RequiresBroadcast
 .. autoclass:: RequiresMap
 .. autoclass:: RequiresVarFilter
+.. autoclass:: RequiresConfiguration
 
 
 Instance definition

--- a/pelix/ipopo/configadmin.py
+++ b/pelix/ipopo/configadmin.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Bridge between ConfigurationAdmin and iPOPO
+
+Lets an administrator manage a composition at runtime: each factory
+configuration created with the ``pelix.ipopo.component`` PID describes a
+component instance, and any component declaring a ``service.pid`` property is
+reconfigured by the configuration with that PID.
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+:version: 3.2.2
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import itertools
+import logging
+import threading
+from typing import Any, NamedTuple
+
+from pelix import services
+from pelix.constants import SERVICE_PID
+from pelix.framework import BundleContext
+from pelix.internals.registry import ServiceRegistration
+from pelix.ipopo.constants import (
+    HANDLER_CONFIGADMIN,
+    IPOPO_CONFIG_FACTORY_NAME,
+    IPOPO_CONFIG_UPDATE_POLICY,
+    IPOPO_CONFIGADMIN_FACTORY_PID,
+    IPOPO_INSTANCE_NAME,
+    UPDATE_POLICY_RESTART,
+    IPopoEvent,
+    IPopoEventListener,
+    IPopoService,
+    IPopoWaitingList,
+)
+from pelix.ipopo.decorators import (
+    ComponentFactory,
+    Instantiate,
+    Invalidate,
+    Property,
+    Provides,
+    Requires,
+    Validate,
+)
+
+# ------------------------------------------------------------------------------
+
+# Module version
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+# ------------------------------------------------------------------------------
+
+_logger = logging.getLogger(__name__)
+
+_MANAGED_SPECIFICATIONS = frozenset(
+    (
+        services.SERVICE_CONFIGADMIN_MANAGED,
+        services.SERVICE_CONFIGADMIN_MANAGED_FACTORY,
+    )
+)
+""" Specifications of the components which handle their configuration themselves """
+
+_CONFIG_DIRECTIVES = frozenset((IPOPO_CONFIG_FACTORY_NAME, IPOPO_CONFIG_UPDATE_POLICY))
+""" Configuration entries which drive the bridge and are not component properties """
+
+# ------------------------------------------------------------------------------
+
+
+def _factory_defaults(ipopo: IPopoService, factory: str, keys: set[str]) -> dict[str, Any]:
+    """
+    Returns the values declared by a factory for the given property names.
+    A missing property maps to None; a dot-prefixed key (e.g. ``.password``)
+    maps to the declared default of the ``@HiddenProperty`` named without its
+    leading dot.
+
+    :param ipopo: The iPOPO service
+    :param factory: Name of a component factory
+    :param keys: Names of the properties to look for
+    :return: A dictionary: property name -> declared value
+    """
+    try:
+        details = ipopo.get_factory_details(factory)
+        declared = details["properties"]
+        hidden_declared = details["hidden_properties"]
+    except ValueError:
+        # Factory has gone away
+        declared = {}
+        hidden_declared = {}
+
+    result: dict[str, Any] = {}
+    for key in keys:
+        if key.startswith(".") and key[1:] in hidden_declared:
+            result[key] = hidden_declared[key[1:]]
+        else:
+            result[key] = declared.get(key)
+    return result
+
+
+# ------------------------------------------------------------------------------
+
+
+class _ComponentConfig(NamedTuple):
+    """
+    Description of the component asked for by a factory configuration
+    """
+
+    factory: str
+    """ Name of the iPOPO component factory """
+
+    name: str
+    """ Name of the component instance """
+
+    properties: dict[str, Any]
+    """ Properties given by the configuration """
+
+    restart: bool
+    """ True if an update of the configuration must restart the component """
+
+
+@ComponentFactory("ipopo-configadmin-instantiator-factory")
+@Provides(services.IManagedServiceFactory)
+@Property("_pid", SERVICE_PID, IPOPO_CONFIGADMIN_FACTORY_PID)
+@Requires("_ipopo", IPopoService)
+@Requires("_waiting", IPopoWaitingList)
+@Instantiate("ipopo-configadmin-instantiator")
+class ConfigAdminInstantiator(services.IManagedServiceFactory):
+    """
+    Instantiates a component per factory configuration of the
+    ``pelix.ipopo.component`` PID, through the iPOPO waiting list.
+    """
+
+    # Injected services
+    _ipopo: IPopoService
+    _waiting: IPopoWaitingList
+
+    def __init__(self) -> None:
+        """
+        Sets up members
+        """
+        # Handled PID of this managed service factory
+        self._pid: str = IPOPO_CONFIGADMIN_FACTORY_PID
+
+        # Configuration PID -> component described by the configuration
+        self._wanted: dict[str, _ComponentConfig] = {}
+
+        # Configuration PID -> component which has been created for it
+        self._applied: dict[str, _ComponentConfig] = {}
+
+        # PIDs a thread is currently working on
+        self._applying: set[str] = set()
+
+        # True between the validation and the invalidation of the component
+        self._active = False
+
+        # Protects the state above. It is never held while calling iPOPO:
+        # instantiating or killing a component runs its callbacks, which can
+        # notify this service back from another thread
+        self.__lock = threading.Lock()
+
+    @Validate
+    def _validate(self, _: BundleContext) -> None:
+        """
+        Component validated
+        """
+        with self.__lock:
+            self._active = True
+
+    @Invalidate
+    def _invalidate(self, _: BundleContext) -> None:
+        """
+        Component invalidated: kill the components created from configurations,
+        as ConfigurationAdmin doesn't notify the deletion of this service
+        """
+        with self.__lock:
+            self._active = False
+            pids = set(self._wanted).union(self._applied)
+
+        for pid in pids:
+            self.__reconcile(pid, None)
+
+    def get_name(self) -> str:
+        """
+        Returns the PID of this managed service factory
+        """
+        return self._pid
+
+    def updated(self, pid: str, properties: dict[str, Any] | None) -> None:
+        """
+        A configuration describing a component has been created or updated
+
+        :param pid: PID of the configuration
+        :param properties: Properties of the configuration
+        """
+        if properties is None:
+            self.deleted(pid)
+            return
+
+        factory = properties.get(IPOPO_CONFIG_FACTORY_NAME)
+        if not factory:
+            _logger.error(
+                "Configuration %s doesn't give the name of the iPOPO factory to instantiate (%s)",
+                pid,
+                IPOPO_CONFIG_FACTORY_NAME,
+            )
+
+            # The configuration doesn't describe a component anymore: an
+            # update replaces the whole set of properties, so the factory name
+            # can be dropped by a caller which forgot to give it back
+            self.deleted(pid)
+            return
+
+        self.__reconcile(
+            pid,
+            _ComponentConfig(
+                factory,
+                # The instance name defaults to the configuration PID
+                properties.get(IPOPO_INSTANCE_NAME) or pid,
+                # The entries driving the bridge are directives, not component
+                # properties
+                {key: value for key, value in properties.items() if key not in _CONFIG_DIRECTIVES},
+                properties.get(IPOPO_CONFIG_UPDATE_POLICY) == UPDATE_POLICY_RESTART,
+            ),
+        )
+
+    def deleted(self, pid: str) -> None:
+        """
+        A configuration describing a component has been deleted: kill it
+
+        :param pid: PID of the configuration
+        """
+        self.__reconcile(pid, None)
+
+    def __reconcile(self, pid: str, wanted: _ComponentConfig | None) -> None:
+        """
+        Makes the running components match the configuration with the given
+        PID. Only one thread works on a given PID at a time: a concurrent
+        call just stores the new target state, which that thread picks up
+        before returning. Never holds the lock across an iPOPO call, since a
+        component callback can notify this service back from another thread.
+
+        :param pid: PID of the configuration
+        :param wanted: The component the configuration asks for, None if the
+                       configuration is gone
+        """
+        with self.__lock:
+            if wanted is None:
+                self._wanted.pop(pid, None)
+            elif not self._active:
+                # Ignore: received after invalidation, the component must not
+                # outlive this service
+                return
+            else:
+                self._wanted[pid] = wanted
+
+            if pid in self._applying:
+                # Another thread is on it, it will see the new target state
+                return
+
+            self._applying.add(pid)
+
+        try:
+            while True:
+                with self.__lock:
+                    target = self._wanted.get(pid)
+                    current = self._applied.get(pid)
+                    if target == current:
+                        self._applying.discard(pid)
+                        return
+
+                applied, forget = self.__apply(current, target)
+
+                with self.__lock:
+                    if applied is None:
+                        self._applied.pop(pid, None)
+                    else:
+                        self._applied[pid] = applied
+
+                    if forget and self._wanted.get(pid) is target:
+                        # Couldn't apply the configuration: align the target
+                        # on what's running, else this would retry forever
+                        if applied is None:
+                            del self._wanted[pid]
+                        else:
+                            self._wanted[pid] = applied
+        except BaseException:
+            with self.__lock:
+                self._applying.discard(pid)
+            raise
+
+    def __apply(
+        self, current: _ComponentConfig | None, target: _ComponentConfig | None
+    ) -> tuple[_ComponentConfig | None, bool]:
+        """
+        Applies a change of configuration. Doesn't raise exceptions.
+
+        :param current: The component which is running, None if there is none
+        :param target: The component to run, None to kill the running one
+        :return: The component running afterwards (None if none), and whether
+                 the target state must be given up and aligned on it instead
+        """
+        if target is None:
+            # Configuration deleted
+            if current is not None:
+                self.__remove(current.name)
+            return None, False
+
+        if (
+            current is None
+            or current.factory != target.factory
+            or current.name != target.name
+            or target.restart
+        ):
+            # Nothing running yet, or a component which must be created again
+            if current is not None:
+                self.__remove(current.name)
+            return (target, False) if self.__add(target) else (None, True)
+
+        # Give back their declared value to the properties which are not in the
+        # configuration anymore
+        properties = dict(target.properties)
+        removed = set(current.properties).difference(properties)
+        if removed:
+            properties.update(_factory_defaults(self._ipopo, target.factory, removed))
+
+        try:
+            self._waiting.update(target.name, properties, removed)
+        except KeyError:
+            # Component has been forgotten by the waiting list: start it again
+            return (target, False) if self.__add(target) else (None, True)
+        except ValueError as ex:
+            # The waiting list has lost its context: its bundle is stopping,
+            # which will invalidate this component too. The component is still
+            # running: keep tracking it, else the deletion of its
+            # configuration wouldn't kill it
+            _logger.error("Can't update the component %s: %s", target.name, ex)
+            return current, True
+
+        return target, False
+
+    def __remove(self, name: str) -> None:
+        """
+        Removes a component from the waiting list, which kills it. Hides the
+        errors of an already forgotten component.
+
+        :param name: A component instance name
+        """
+        try:
+            self._waiting.remove(name)
+        except (KeyError, ValueError):
+            # Component was already forgotten, or the waiting list is gone
+            pass
+
+    def __add(self, config: _ComponentConfig) -> bool:
+        """
+        Adds a component to the waiting list. Hides the error of a name which
+        is already in use.
+
+        :param config: Description of the component to instantiate
+        :return: True if the component has been added to the waiting list
+        """
+        try:
+            self._waiting.add(config.factory, config.name, dict(config.properties))
+        except ValueError as ex:
+            _logger.error("Can't instantiate the component %s: %s", config.name, ex)
+            return False
+
+        return True
+
+
+# ------------------------------------------------------------------------------
+
+
+class _ManagedInstance(services.IManagedService):
+    """
+    Applies the properties of a configuration to an existing component.
+
+    A property which leaves the configuration goes back to the value declared
+    by the factory: the values given when the component was instantiated are
+    unknown here, contrary to the handler of ``@RequiresConfiguration``.
+    """
+
+    def __init__(self, ipopo: IPopoService, factory: str, name: str) -> None:
+        """
+        :param ipopo: The iPOPO service
+        :param factory: Name of the factory of the component
+        :param name: Name of the component instance
+        """
+        self._ipopo = ipopo
+        self._factory = factory
+        self._name = name
+
+        # Properties given by the configuration
+        self._configured: set[str] = set()
+
+        # Serializes the updates: the initial notification is given by the
+        # pool of ConfigurationAdmin while the next ones are given in the
+        # thread of the caller of Configuration.update()
+        self.__lock = threading.RLock()
+
+    def updated(self, properties: dict[str, Any] | None) -> None:
+        """
+        The configuration of the component has been updated or deleted
+
+        :param properties: The new configuration properties, None if the
+                           configuration has been deleted
+        """
+        with self.__lock:
+            self.__updated(properties)
+
+    def __updated(self, properties: dict[str, Any] | None) -> None:
+        """
+        Computes and applies the update of the properties of the component.
+        Must be called with the update lock held.
+
+        :param properties: The new configuration properties, None if the
+                           configuration has been deleted
+        """
+        if properties is None:
+            # Configuration deleted: give back their declared value
+            update = _factory_defaults(self._ipopo, self._factory, self._configured)
+            self._configured = set()
+        else:
+            # The entries describing the configuration itself are not component
+            # properties: the factory doesn't declare the PID of the component,
+            # so it couldn't be restored when the configuration goes away
+            update = {
+                key: value for key, value in properties.items() if key not in services.CONFIG_ADMIN_PROPERTIES
+            }
+            configured = set(update)
+
+            # Give back their declared value to the properties which are not in
+            # the configuration anymore
+            removed = self._configured.difference(configured)
+            if removed:
+                update.update(_factory_defaults(self._ipopo, self._factory, removed))
+
+            self._configured = configured
+
+        try:
+            self._ipopo.reconfigure(self._name, update)
+        except ValueError:
+            # Component has been killed in the meantime
+            pass
+
+
+@ComponentFactory("ipopo-configadmin-configurator-factory")
+@Requires("_ipopo", IPopoService)
+@Instantiate("ipopo-configadmin-configurator")
+class ConfigAdminConfigurator(IPopoEventListener):
+    """
+    Binds every component declaring a ``service.pid`` property to the
+    configuration with that PID: its entries are injected in the properties of
+    the component.
+
+    Components created from a factory configuration (see
+    :class:`ConfigAdminInstantiator`), those using the
+    ``@RequiresConfiguration`` decorator and those providing a managed service
+    are ignored: they already follow their own configuration.
+    """
+
+    # Injected services
+    _ipopo: IPopoService
+
+    def __init__(self) -> None:
+        """
+        Sets up members
+        """
+        self._context: BundleContext | None = None
+
+        # Component name -> registration of its managed service
+        self._registrations: dict[str, ServiceRegistration[services.IManagedService]] = {}
+
+        # Component name -> identifier of the tracking in progress
+        self._tracking: dict[str, int] = {}
+        self.__counter = itertools.count()
+        self.__lock = threading.RLock()
+
+    @Validate
+    def _validate(self, context: BundleContext) -> None:
+        """
+        Component validated
+        """
+        self._context = context
+        self._ipopo.add_listener(self)
+
+        # Handle the components which are already running
+        for name, factory, _ in self._ipopo.get_instances():
+            self.__track(factory, name)
+
+    @Invalidate
+    def _invalidate(self, _: BundleContext) -> None:
+        """
+        Component invalidated
+        """
+        self._ipopo.remove_listener(self)
+
+        with self.__lock:
+            registrations = list(self._registrations.values())
+            self._registrations.clear()
+
+            # Abort the trackings in progress
+            self._tracking.clear()
+
+        for registration in registrations:
+            registration.unregister()
+
+        self._context = None
+
+    def handle_ipopo_event(self, event: IPopoEvent) -> None:
+        """
+        Handles an iPOPO event
+
+        :param event: The iPOPO event
+        """
+        name = event.get_component_name()
+        if name is None:
+            return
+
+        kind = event.get_kind()
+        if kind == IPopoEvent.INSTANTIATED:
+            self.__track(event.get_factory_name(), name)
+        elif kind == IPopoEvent.KILLED:
+            self.__forget(name)
+
+    def __track(self, factory: str, name: str) -> None:
+        """
+        Registers a managed service for the given component, if it declares a
+        PID and doesn't already follow a configuration
+
+        :param factory: Name of the factory of the component
+        :param name: Name of the component instance
+        """
+        with self.__lock:
+            if self._context is None or name in self._registrations or name in self._tracking:
+                # Not running, component already followed or already looked at
+                return
+
+            # Remember this tracking: the properties of the component are read
+            # outside of the lock, and the component can be killed meanwhile
+            tracking = next(self.__counter)
+            self._tracking[name] = tracking
+
+        pid = self.__component_pid(factory, name)
+
+        with self.__lock:
+            if self._tracking.get(name) != tracking:
+                # The component has been killed while its properties were read
+                return
+
+            del self._tracking[name]
+            if pid is None or self._context is None or name in self._registrations:
+                return
+
+            self._registrations[name] = self._context.register_service(
+                services.IManagedService,
+                _ManagedInstance(self._ipopo, factory, name),
+                {SERVICE_PID: pid},
+            )
+
+    def __component_pid(self, factory: str, name: str) -> str | None:
+        """
+        Returns the PID of the configuration the given component must follow,
+        None if it declares none or if it already follows a configuration by
+        itself
+
+        :param factory: Name of the factory of the component
+        :param name: Name of the component instance
+        :return: A configuration PID or None
+        """
+        try:
+            # Read the real properties: get_instance_details() converts them to
+            # their string representation, which would turn a declared but
+            # unset PID into the "None" string
+            properties = self._ipopo.get_instance_properties(name)
+        except ValueError:
+            # Component is not running (anymore)
+            return None
+
+        pid = properties.get(SERVICE_PID)
+        if not pid:
+            # Nothing to follow
+            return None
+
+        if not isinstance(pid, str):
+            _logger.warning(
+                "Component %s declares a non-string %s property (%r): it is ignored",
+                name,
+                SERVICE_PID,
+                pid,
+            )
+            return None
+
+        if properties.get(services.CONFIG_PROP_FACTORY_PID) == IPOPO_CONFIGADMIN_FACTORY_PID:
+            # Component created from a factory configuration
+            return None
+
+        try:
+            details = self._ipopo.get_factory_details(factory)
+        except ValueError:
+            # Factory has gone away
+            return None
+
+        if HANDLER_CONFIGADMIN in details["handlers"]:
+            # Component uses @RequiresConfiguration
+            return None
+
+        provided = {spec for specifications in details["services"] for spec in specifications}
+        if provided.intersection(_MANAGED_SPECIFICATIONS):
+            # Component talks to ConfigurationAdmin by itself
+            return None
+
+        return pid
+
+    def __forget(self, name: str) -> None:
+        """
+        Unregisters the managed service associated to the given component
+
+        :param name: Name of the component instance
+        """
+        with self.__lock:
+            # Abort the tracking in progress, if any
+            self._tracking.pop(name, None)
+            registration = self._registrations.pop(name, None)
+
+        if registration is not None:
+            registration.unregister()

--- a/pelix/ipopo/constants.py
+++ b/pelix/ipopo/constants.py
@@ -26,7 +26,7 @@ Defines some iPOPO constants
 """
 
 import contextlib
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from typing import Any, Protocol, cast
 
 from pelix.constants import BundleException, Specification
@@ -78,6 +78,9 @@ HANDLER_PROVIDES = "ipopo.provides"
 
 HANDLER_PROPERTY = "ipopo.properties"
 """ The @Property handler ID """
+
+HANDLER_CONFIGADMIN = "ipopo.configadmin"
+""" The @RequiresConfiguration handler ID """
 
 # ------------------------------------------------------------------------------
 
@@ -181,6 +184,34 @@ updated
 
 # ------------------------------------------------------------------------------
 
+IPOPO_CONFIGADMIN_FACTORY_PID = "pelix.ipopo.component"
+"""
+Factory PID handled by the iPOPO ConfigurationAdmin bridge: each factory
+configuration created with this PID describes a component instance
+"""
+
+IPOPO_CONFIG_FACTORY_NAME = "ipopo.factory.name"
+""" Configuration property: name of the iPOPO factory to instantiate """
+
+IPOPO_CONFIG_UPDATE_POLICY = "ipopo.update.policy"
+"""
+Configuration property: how a component reacts to the update of its
+configuration, either ``reconfigure`` (default) or ``restart``
+"""
+
+UPDATE_POLICY_RECONFIGURE = "reconfigure"
+""" Update policy: the properties of the live component are updated in place """
+
+UPDATE_POLICY_RESTART = "restart"
+"""
+Update policy: the component created from a factory configuration is killed
+then instantiated again. A component using ``@RequiresConfiguration`` is only
+invalidated then validated again, so that its ``@Validate`` callback sees the
+new properties
+"""
+
+# ------------------------------------------------------------------------------
+
 
 class IPopoEvent:
     """
@@ -280,6 +311,22 @@ class IPopoService(Protocol):
         :raise ValueError: The given name or factory name is invalid, or an
                            instance with the given name already exists
         :raise Exception: Something wrong occurred in the factory
+        """
+        ...
+
+    def reconfigure(self, name: str, properties: dict[str, Any]) -> None:
+        """
+        Updates the properties of a running component. The given properties are
+        merged into the current ones: entries that are not given are left
+        unchanged. The name of the instance can't be modified. A property
+        declared with ``@HiddenProperty`` is ignored unless its name is given
+        prefixed with a dot (e.g. ``.password`` to update the property
+        declared as ``password``), in which case its value is updated without
+        ever becoming public.
+
+        :param name: Name of the component to reconfigure
+        :param properties: The properties to update
+        :raise ValueError: Invalid component name
         """
         ...
 
@@ -402,6 +449,19 @@ class IPopoService(Protocol):
         """
         ...
 
+    def get_instance_properties(self, name: str) -> dict[str, Any]:
+        """
+        Returns a copy of the properties of the given component instance, with
+        their real value: contrary to ``get_instance_details()``, the values
+        are not converted to their string representation. The properties
+        declared with ``@HiddenProperty`` are not returned.
+
+        :param name: The name of a component instance
+        :return: A dictionary: property name -> value
+        :raise ValueError: Invalid component name
+        """
+        ...
+
     def get_instance_details(self, name: str) -> dict[str, Any]:
         """
         Retrieves a snapshot of the given component instance.
@@ -460,6 +520,9 @@ class IPopoService(Protocol):
         * ``name``: The factory name
         * ``bundle``: The Bundle object of the bundle providing the factory
         * ``properties``: Copy of the components properties defined by the factory
+        * ``hidden_properties``: Copy of the declared default values of the
+          properties declared with ``@HiddenProperty`` (never their current,
+          possibly confidential, runtime value)
         * ``requirements``: List of the requirements defined by the factory
 
           * ``id``: Requirement ID (field where it is injected)
@@ -496,6 +559,29 @@ class IPopoWaitingList(Protocol):
         :param properties: Component properties
         :raise ValueError: Component name already reserved in the queue
         :raise Exception: Error instantiating the component
+        """
+        ...
+
+    def update(
+        self, component: str, properties: dict[str, Any], removed: Iterable[str] | None = None
+    ) -> None:
+        """
+        Updates the properties of a queued component. The given properties are
+        merged into the current ones: entries that are not given are left
+        unchanged. If the component is already instantiated, its properties are
+        updated in place.
+
+        The names given in ``removed`` are dropped from the queued properties,
+        so that the next instantiation of the component uses the value declared
+        by its factory. A value given for them in ``properties`` is still
+        applied to the running component, which lets the caller give back their
+        declared value right away.
+
+        :param component: A component name
+        :param properties: The properties to update
+        :param removed: Names of the properties to drop from the queue
+        :raise KeyError: Unknown component
+        :raise ValueError: The waiting list has no bundle context
         """
         ...
 

--- a/pelix/ipopo/core.py
+++ b/pelix/ipopo/core.py
@@ -725,6 +725,27 @@ class _IPopoService(IPopoService):
 
         return instance
 
+    def reconfigure(self, name: str, properties: dict[str, Any]) -> None:
+        """
+        Updates the properties of a running component. The given properties are
+        merged into the current ones: entries that are not given are left
+        unchanged. The name of the instance and the hidden properties can't be
+        modified.
+
+        :param name: Name of the component to reconfigure
+        :param properties: The properties to update
+        :raise ValueError: Invalid component name
+        """
+        with self.__instances_lock:
+            try:
+                stored_instance = self.__instances[name]
+            except KeyError:
+                raise ValueError(f"Unknown component instance '{name}'")
+
+        # Reconfigure outside of the registry lock: the callbacks it triggers
+        # can call back into the iPOPO service, which would take that lock
+        stored_instance.reconfigure(properties)
+
     def retry_erroneous(self, name: str, properties_update: dict[str, Any] | None = None) -> int:
         """
         Removes the ERRONEOUS state of the given component, and retries a validation
@@ -958,6 +979,34 @@ class _IPopoService(IPopoService):
             result.sort()
             return result
 
+    def get_instance_properties(self, name: str) -> dict[str, Any]:
+        """
+        Returns a copy of the properties of the given component instance, with
+        their real value: contrary to ``get_instance_details()``, the values
+        are not converted to their string representation. The hidden
+        properties are not returned.
+
+        :param name: The name of a component instance
+        :return: A dictionary: property name -> value
+        :raise ValueError: Invalid component name
+        """
+        if not is_string(name):
+            raise ValueError("Component name must be a string")
+
+        with self.__instances_lock:
+            try:
+                stored_instance = self.__instances[name]
+            except KeyError:
+                raise ValueError(f"Unknown component: {name}")
+
+            with stored_instance._lock:
+                context = stored_instance.context
+                if context is None:
+                    # Component has been killed
+                    raise ValueError(f"Unknown component: {name}")
+
+                return context.properties.copy()
+
     def get_instance_details(self, name: str) -> dict[str, Any]:
         """
         Retrieves a snapshot of the given component instance.
@@ -1090,6 +1139,9 @@ class _IPopoService(IPopoService):
         * ``name``: The factory name
         * ``bundle``: The Bundle object of the bundle providing the factory
         * ``properties``: Copy of the components properties defined by the factory
+        * ``hidden_properties``: Copy of the declared default values of the
+          properties declared with ``@HiddenProperty`` (never their current,
+          possibly confidential, runtime value)
         * ``requirements``: List of the requirements defined by the factory
 
           * ``id``: Requirement ID (field where it is injected)
@@ -1130,6 +1182,11 @@ class _IPopoService(IPopoService):
                 prop_name: context.properties.get(prop_name)
                 for prop_name in context.properties_fields.values()
             }
+
+            # Declared default values of the properties declared with
+            # @HiddenProperty (never their current, possibly confidential,
+            # runtime value)
+            result["hidden_properties"] = dict(context.hidden_properties)
 
             # Requirements (list of dictionaries)
             handler_requires = cast(

--- a/pelix/ipopo/decorators.py
+++ b/pelix/ipopo/decorators.py
@@ -741,6 +741,13 @@ class HiddenProperty(Property):
     This decorator has the same handler, accepts the same parameters and
     follows the same rules as the :class:`Property` decorator.
 
+    A hidden property can't be updated through a call to
+    :meth:`~pelix.ipopo.constants.IPopoService.reconfigure` or through
+    ConfigurationAdmin using its declared name: a matching entry is ignored.
+    It can still be updated confidentially by prefixing its name with a dot,
+    e.g. ``.some.password`` to update the property declared as
+    ``some.password``: the new value is applied but never becomes public.
+
     :Handler ID: :py:const:`pelix.ipopo.constants.HANDLER_PROPERTY`
 
     :Example:
@@ -1528,6 +1535,101 @@ class Temporal(Requires):
         if not context.completed:
             config = context.set_handler_default(self.HANDLER_ID, {})
             config[self._field] = (self._requirement, self._timeout)
+        return clazz
+
+
+# ------------------------------------------------------------------------------
+
+
+class RequiresConfiguration:
+    """
+    The ``@RequiresConfiguration`` decorator binds the component to a
+    ConfigurationAdmin configuration: the properties of that configuration are
+    injected into the component properties, and, unless the requirement is
+    optional, the component stays invalid as long as no valid configuration is
+    available.
+
+    It requires the ``pelix.ipopo.handlers.configadmin`` bundle to be installed,
+    else the components of the decorated factory stay in the waiting list.
+
+    :Handler ID: :py:const:`pelix.ipopo.constants.HANDLER_CONFIGADMIN`
+
+    :Example:
+
+      .. code-block:: python
+
+          @ComponentFactory()
+          @Property("_name", "name", "world")
+          @RequiresConfiguration("sample.hello")
+          @Instantiate("hello")
+          class Bar:
+              # This component is validated only once the "sample.hello"
+              # configuration exists. Its entries are then injected in the
+              # component properties, i.e. "name" here.
+              pass
+    """
+
+    HANDLER_ID = constants.HANDLER_CONFIGADMIN
+    """ ID of the handler configured by this decorator """
+
+    def __init__(
+        self,
+        pid: str | None = None,
+        optional: bool = False,
+        update_policy: str = constants.UPDATE_POLICY_RECONFIGURE,
+    ) -> None:
+        """
+        :param pid: PID of the configuration to use. If None, the value of the
+                    ``service.pid`` property of the component is used
+        :param optional: If True, the component is validated even if no
+                         configuration is available
+        :param update_policy: Either ``reconfigure`` (default), to update the
+                              properties of the live component, or ``restart``,
+                              to invalidate it before applying them, so that
+                              its ``@Validate`` callback is called again
+        :raise TypeError: A parameter has an invalid type
+        :raise ValueError: An argument is incorrect
+        """
+        if pid is not None:
+            if not is_string(pid):
+                raise TypeError("Configuration PID must be a string")
+
+            pid = pid.strip()
+            if not pid:
+                raise ValueError("Configuration PID can't be empty")
+
+        if update_policy not in (
+            constants.UPDATE_POLICY_RECONFIGURE,
+            constants.UPDATE_POLICY_RESTART,
+        ):
+            raise ValueError(f"Unknown update policy: {update_policy}")
+
+        self.__pid = pid
+        self.__optional = bool(optional)
+        self.__update_policy = update_policy
+
+    def __call__(self, clazz: type[T]) -> type[T]:
+        """
+        Stores the configuration requirement in the factory context
+
+        :param clazz: The class to decorate
+        :return: The decorated class
+        :raise TypeError: If *clazz* is not a type
+        """
+        if not inspect.isclass(clazz):
+            raise TypeError(f"@RequiresConfiguration can decorate only classes, not '{type(clazz).__name__}'")
+
+        context = get_factory_context(clazz)
+        if not context.completed:
+            context.set_handler(
+                self.HANDLER_ID,
+                {
+                    "pid": self.__pid,
+                    "optional": self.__optional,
+                    "update_policy": self.__update_policy,
+                },
+            )
+
         return clazz
 
 

--- a/pelix/ipopo/handlers/configadmin.py
+++ b/pelix/ipopo/handlers/configadmin.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+ConfigurationAdmin handler, for the @RequiresConfiguration decorator
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+:version: 3.2.2
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import logging
+import threading
+from collections.abc import Iterable
+from typing import Any
+
+import pelix.constants
+import pelix.ipopo.constants as ipopo_constants
+from pelix import services
+from pelix.constants import ActivatorProto, BundleActivator
+from pelix.framework import BundleContext
+from pelix.internals.registry import ServiceRegistration
+from pelix.ipopo.contexts import ComponentContext
+from pelix.ipopo.handlers import constants
+from pelix.ipopo.instance import StoredInstance
+
+# ------------------------------------------------------------------------------
+
+# Module version
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+# ------------------------------------------------------------------------------
+
+_logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------------------
+
+
+class _HandlerFactory(constants.HandlerFactory):
+    """
+    Factory service for configuration handlers
+    """
+
+    def get_handlers(self, component_context: ComponentContext, instance: Any) -> Iterable[constants.Handler]:
+        """
+        Sets up the configuration handler of the given component
+
+        :param component_context: The ComponentContext bean
+        :param instance: The component instance
+        :return: The list of handlers associated to the given component
+        """
+        config = component_context.get_handler(ipopo_constants.HANDLER_CONFIGADMIN)
+        if config is None:
+            return ()
+
+        # The PID can be given by the decorator or by a component property
+        pid = config.get("pid") or component_context.properties.get(pelix.constants.SERVICE_PID)
+        return (
+            ConfigurationHandler(
+                pid,
+                config.get("optional", False),
+                config.get("update_policy", ipopo_constants.UPDATE_POLICY_RECONFIGURE),
+            ),
+        )
+
+
+@BundleActivator
+class Activator(ActivatorProto):
+    """
+    The bundle activator
+    """
+
+    def __init__(self) -> None:
+        """
+        Sets up members
+        """
+        self._registration: ServiceRegistration[constants.HandlerFactory] | None = None
+
+    def start(self, context: BundleContext) -> None:
+        """
+        Bundle started
+        """
+        # Register the handler factory service
+        self._registration = context.register_service(
+            constants.HandlerFactory,
+            _HandlerFactory(),
+            {constants.PROP_HANDLER_ID: ipopo_constants.HANDLER_CONFIGADMIN},
+        )
+
+    def stop(self, context: BundleContext) -> None:
+        """
+        Bundle stopped
+        """
+        if self._registration is not None:
+            # Unregister the service
+            self._registration.unregister()
+            self._registration = None
+
+
+# ------------------------------------------------------------------------------
+
+
+class ConfigurationHandler(constants.Handler, services.IManagedService):
+    """
+    Injects the properties of a ConfigurationAdmin configuration into the
+    component and, if the requirement is not optional, keeps the component
+    invalid until that configuration exists.
+    """
+
+    def __init__(self, pid: str | None, optional: bool, update_policy: str) -> None:
+        """
+        :param pid: PID of the configuration to follow
+        :param optional: If True, the component is valid without configuration
+        :param update_policy: Reaction to a configuration update
+        """
+        super().__init__()
+        self._pid = pid
+        self._optional = optional
+        self._update_policy = update_policy
+
+        self._ipopo_instance: StoredInstance | None = None
+        self._registration: ServiceRegistration[services.IManagedService] | None = None
+        self._configured = False
+
+        # Protects the state of the handler
+        self._lock = threading.RLock()
+
+        # Serializes the updates coming from the ConfigurationAdmin pool: the
+        # state lock can't be used for that, as it must not be held while
+        # calling the stored instance
+        self.__update_lock = threading.RLock()
+
+        # Default value of the properties given by the configuration, to be
+        # restored when the configuration is deleted
+        self._defaults: dict[str, Any] = {}
+
+    def get_kinds(self) -> tuple[str]:
+        """
+        Returns the kinds of this handler
+        """
+        return (constants.KIND_CONFIGURATION,)
+
+    def manipulate(self, stored_instance: StoredInstance, component_instance: Any) -> None:
+        """
+        Stores the stored instance of the component
+
+        :param stored_instance: The iPOPO component StoredInstance
+        :param component_instance: The component instance
+        """
+        self._ipopo_instance = stored_instance
+
+    def is_valid(self) -> bool:
+        """
+        The component can be validated only if its configuration is available,
+        unless the requirement is optional
+        """
+        return self._optional or self._configured
+
+    def start(self) -> None:
+        """
+        Registers the managed service which will receive the configuration
+        """
+        if self._ipopo_instance is None:
+            return
+
+        if not self._pid:
+            _logger.warning(
+                "Component %s requires a configuration but has no PID",
+                self._ipopo_instance.name,
+            )
+            return
+
+        self._registration = self._ipopo_instance.bundle_context.register_service(
+            services.IManagedService, self, {pelix.constants.SERVICE_PID: self._pid}
+        )
+
+    def stop(self) -> None:
+        """
+        Unregisters the managed service
+        """
+        if self._registration is not None:
+            self._registration.unregister()
+            self._registration = None
+
+    def clear(self) -> None:
+        """
+        Releases all references
+        """
+        with self._lock:
+            self._ipopo_instance = None
+            self._defaults.clear()
+
+    def updated(self, properties: dict[str, Any] | None) -> None:
+        """
+        The configuration of the component has been updated or deleted
+
+        :param properties: The new configuration properties, None if the
+                           configuration has been deleted
+        """
+        # The update lock is taken first: the state lock must be released
+        # before calling the stored instance, which takes its own lock
+        with self.__update_lock:
+            with self._lock:
+                stored_instance = self._ipopo_instance
+                # Read the context once: the component can be killed at any time
+                context = stored_instance.context if stored_instance is not None else None
+                if stored_instance is None or context is None:
+                    # Component has been killed
+                    return
+
+                if properties is None:
+                    # Configuration deleted: go back to the declared values
+                    self._configured = False
+                    update = self._defaults
+                    self._defaults = {}
+                else:
+                    # The entries describing the configuration itself are not
+                    # component properties
+                    configured = {
+                        key: value
+                        for key, value in properties.items()
+                        if key not in services.CONFIG_ADMIN_PROPERTIES
+                    }
+
+                    # Keep the declared value of the new properties, to restore
+                    # them when they leave the configuration
+                    current = context.properties
+                    hidden_defaults = context.factory_context.hidden_properties
+                    for key in configured:
+                        if key not in self._defaults:
+                            if key.startswith(".") and key[1:] in hidden_defaults:
+                                # Dot-prefixed override of a hidden property:
+                                # its declared value isn't in context.properties
+                                self._defaults[key] = hidden_defaults[key[1:]]
+                            else:
+                                self._defaults[key] = current.get(key)
+
+                    update = dict(configured)
+
+                    # Give back their declared value to the properties which
+                    # are not in the configuration anymore
+                    for key in set(self._defaults).difference(configured):
+                        update[key] = self._defaults.pop(key)
+
+                    self._configured = True
+
+            try:
+                # With the restart policy, the component is invalidated before
+                # the new properties are applied and validated again
+                # afterwards, all of it in a single lock acquisition
+                stored_instance.reconfigure(
+                    update, self._update_policy == ipopo_constants.UPDATE_POLICY_RESTART
+                )
+            except ValueError:
+                # Component has been killed in the meantime
+                pass

--- a/pelix/ipopo/handlers/constants.py
+++ b/pelix/ipopo/handlers/constants.py
@@ -65,6 +65,12 @@ Represents the 'properties' kind of handler, which manipulates the component
 to notify property changes.
 """
 
+KIND_CONFIGURATION = "configuration"
+"""
+Represents the 'configuration' kind of handler, which feeds the component with
+the properties of a ConfigurationAdmin configuration.
+"""
+
 KIND_DEPENDENCY = "dependency"
 """
 Represents the 'dependency' kind of handler.

--- a/pelix/ipopo/instance.py
+++ b/pelix/ipopo/instance.py
@@ -72,6 +72,7 @@ class StoredInstance:
     # Try to reduce memory footprint (stored instances)
     __slots__ = (
         "__all_handlers",
+        "__warned_hidden",
         "_controllers_state",
         "_handlers",
         "_ipopo_service",
@@ -142,6 +143,10 @@ class StoredInstance:
 
         # Stack track of validation error
         self.error_trace: str | None = None
+
+        # Hidden properties an update has already been refused for: the
+        # configuration of a component is resent as a whole on every update
+        self.__warned_hidden: set[str] = set()
 
         # Store the bundle context
         self.bundle_context: BundleContext = self.context.get_bundle_context()
@@ -270,6 +275,72 @@ class StoredInstance:
             self.__safe_handlers_callback(
                 handlers_const.Handler.on_property_change, name, old_value, new_value
             )
+
+    def reconfigure(self, properties: dict[str, Any], restart: bool = False) -> None:
+        """
+        Updates the properties of this component. The given properties are
+        merged into the current ones: entries that are not given are left
+        unchanged. The name of the instance can't be modified.
+
+        The properties declared with ``@HiddenProperty`` are ignored: they are
+        given to the component once, when it is created, and are kept out of
+        the reach of the other handlers and of the component details. To
+        update a hidden property's value confidentially, prefix its name with
+        a dot, e.g. ``.password`` to update the property declared as
+        ``password``: the value is applied but still never becomes public.
+
+        :param properties: The properties to update
+        :param restart: If True, invalidate the component before applying the
+                        properties: it is validated again once they are set
+        """
+        with self._lock:
+            if self.context is None:
+                # Component has been killed
+                return
+
+            if restart:
+                # Invalidate in the same lock acquisition as the update:
+                # another thread must not validate the component again with
+                # its previous properties
+                self.invalidate(True)
+
+            hidden = self.context.factory_context.hidden_properties
+            current = self.context.properties
+            for name, new_value in properties.items():
+                if name == constants.IPOPO_INSTANCE_NAME:
+                    # The instance name is read-only
+                    continue
+
+                if name.startswith(".") and name[1:] in hidden:
+                    # Explicit, confidential update of a hidden property:
+                    # apply it through the same path the component itself
+                    # would use, so it still never becomes a public property
+                    hidden_name = name[1:]
+                    setter_name = f"{constants.IPOPO_HIDDEN_PROPERTY_PREFIX}{constants.IPOPO_SETTER_SUFFIX}"
+                    setter = getattr(self.instance, setter_name, None)
+                    if setter is not None:
+                        setter(self.instance, hidden_name, new_value)
+                    continue
+
+                if name in hidden:
+                    # Never make a hidden property public. Warn only once:
+                    # the whole configuration of a component is given back on
+                    # each of its updates
+                    if name not in self.__warned_hidden:
+                        self.__warned_hidden.add(name)
+                        self._logger.warning(
+                            "%s: ignoring the update of the hidden property %s",
+                            self.name,
+                            name,
+                        )
+                    continue
+
+                old_value = current.get(name)
+                if new_value != old_value:
+                    current[name] = new_value
+                    self.update_property(name, old_value, new_value)
+
+            self.check_lifecycle()
 
     def update_hidden_property(self, name: str, old_value: Any, new_value: Any) -> None:
         """

--- a/pelix/ipopo/waiting.py
+++ b/pelix/ipopo/waiting.py
@@ -31,6 +31,7 @@ components.
 # Standard library
 import logging
 import threading
+from collections.abc import Iterable
 from typing import Any
 
 # Pelix
@@ -113,6 +114,29 @@ class IPopoWaitingListImpl(IPopoWaitingList):
             except Exception:
                 # Other error
                 _logger.exception("Error instantiating component %s from factory %s", component, factory)
+            else:
+                with self.__lock:
+                    removed_concurrently = self.__names.get(component) != factory
+                    queued = self.__queue.get(factory, {}).get(component)
+
+                if removed_concurrently:
+                    # remove() raced with this instantiation: its kill()
+                    # attempt failed because the component didn't exist yet.
+                    # Finish the job now that it does
+                    try:
+                        with use_ipopo(self.__context) as ipopo_svc:
+                            ipopo_svc.kill(component)
+                    except (BundleException, ValueError):
+                        pass
+                elif queued is not None and queued is not properties:
+                    # update() raced with this instantiation: it stored a new
+                    # dictionary and its reconfigure() call was lost, as the
+                    # component didn't exist yet. Apply the new properties now
+                    try:
+                        ipopo.reconfigure(component, queued)
+                    except ValueError:
+                        # Component killed in the meantime
+                        pass
 
     def _start(self) -> None:
         """
@@ -225,13 +249,65 @@ class IPopoWaitingListImpl(IPopoWaitingList):
             self.__names[component] = factory
             self.__queue.setdefault(factory, {})[component] = properties
 
-            try:
-                with use_ipopo(self.__context) as ipopo:
-                    # Try to instantiate the component right now
-                    self._try_instantiate(ipopo, factory, component)
-            except BundleException:
-                # iPOPO not yet started
-                pass
+        # Instantiate outside of the lock: the callbacks of the component can
+        # call back into this service from another thread
+        try:
+            with use_ipopo(self.__context) as ipopo:
+                # Try to instantiate the component right now
+                self._try_instantiate(ipopo, factory, component)
+        except BundleException:
+            # iPOPO not yet started
+            pass
+
+    def update(
+        self, component: str, properties: dict[str, Any], removed: Iterable[str] | None = None
+    ) -> None:
+        """
+        Updates the properties of a queued component. The given properties are
+        merged into the current ones: entries that are not given are left
+        unchanged. If the component is already instantiated, its properties are
+        updated in place.
+
+        The names given in ``removed`` are dropped from the queued properties,
+        so that the next instantiation of the component uses the value declared
+        by its factory. A value given for them in ``properties`` is still
+        applied to the running component, which lets the caller give back their
+        declared value right away.
+
+        :param component: A component name
+        :param properties: The properties to update
+        :param removed: Names of the properties to drop from the queue
+        :raise KeyError: Unknown component
+        :raise ValueError: The waiting list has no bundle context
+        """
+        if self.__context is None:
+            raise ValueError("Missing context for iPOPO waiting list")
+
+        with self.__lock:
+            # Find its factory (raises KeyError if the component is unknown)
+            factory = self.__names[component]
+
+            # Keep the merged properties for the next instantiation. Store a
+            # new dictionary: the queued one belongs to the caller of add()
+            queued = {**self.__queue[factory][component], **properties}
+            for key in removed or ():
+                queued.pop(key, None)
+
+            self.__queue[factory][component] = queued
+
+        # Reconfigure outside of the lock (see add())
+        try:
+            with use_ipopo(self.__context) as ipopo:
+                # Update the running component, if any
+                ipopo.reconfigure(component, properties)
+        except BundleException:
+            # iPOPO not yet started
+            pass
+        except ValueError:
+            # Component is not instantiated: this is the normal state of a
+            # component waiting for its factory, the properties above will be
+            # given to it when it is created
+            pass
 
     def remove(self, component: str) -> None:
         """
@@ -254,14 +330,25 @@ class IPopoWaitingListImpl(IPopoWaitingList):
                 # No more component for this factory
                 del self.__queue[factory]
 
-            # Kill the component
-            try:
-                with use_ipopo(self.__context) as ipopo:
-                    # Try to instantiate the component right now
+        # Kill the component outside of the lock (see add())
+        try:
+            with use_ipopo(self.__context) as ipopo:
+                try:
                     ipopo.kill(component)
-            except (BundleException, ValueError):
-                # iPOPO not yet started or component not instantiated
-                pass
+                except ValueError:
+                    # Component not instantiated
+                    pass
+
+                with self.__lock:
+                    new_factory = self.__names.get(component)
+
+                if new_factory is not None and not ipopo.is_registered_instance(component):
+                    # add() raced with this removal: the kill() above destroyed
+                    # the component it had just instantiated. Create it again
+                    self._try_instantiate(ipopo, new_factory, component)
+        except BundleException:
+            # iPOPO not yet started
+            pass
 
 
 # ------------------------------------------------------------------------------

--- a/pelix/services/__init__.py
+++ b/pelix/services/__init__.py
@@ -147,6 +147,13 @@ CONFIG_PROP_FACTORY_PID = "service.factoryPid"
 CONFIG_PROP_BUNDLE_LOCATION = "service.bundleLocation"
 """ Configuration property: bound location (not used yet) """
 
+CONFIG_ADMIN_PROPERTIES = frozenset((CONFIG_PROP_PID, CONFIG_PROP_FACTORY_PID, CONFIG_PROP_BUNDLE_LOCATION))
+"""
+Entries which describe a configuration itself: ConfigurationAdmin adds them to
+the properties it gives to managed services, they don't come from the
+administrator
+"""
+
 
 class Configuration(Protocol):
     """

--- a/pelix/services/configadmin.py
+++ b/pelix/services/configadmin.py
@@ -25,7 +25,6 @@ ConfigurationAdmin implementation
     limitations under the License.
 
 TODO: Stabilize implementation of managed service factories
-FIXME: Add tests for the configuration of managed service factories
 """
 
 import json
@@ -278,6 +277,14 @@ class Configuration(services.Configuration):
         """
         return self.__updated and not self.__deleted
 
+    def is_deleted(self) -> bool:
+        """
+        Checks if this configuration has been deleted
+
+        :return: True if the deletion of this configuration has been started
+        """
+        return self.__deleted
+
     def __properties_update(self, properties: dict[str, Any] | None) -> bool:
         """
         Internal update of configuration properties. Does not notifies the
@@ -355,10 +362,23 @@ class Configuration(services.Configuration):
         :raise IOError: Error storing the configuration
         """
         with self.__lock:
+            if self.__deleted:
+                # The configuration has been deleted while the caller was
+                # working on it: don't store its properties again
+                return
+
             # Update properties
-            if self.__properties_update(properties):
-                # Update configurations, if something changed
+            changed = self.__properties_update(properties)
+
+        # Notify outside of the lock: it is synchronous and the callback can
+        # call back into this or another Configuration object
+        if changed:
+            try:
                 cast(ConfigurationAdmin, self.__config_admin)._update(self)
+            except ValueError:
+                # Deleted concurrently while we were about to notify:
+                # nothing left to update
+                pass
 
     def delete(self, directory_updated: bool = False) -> None:
         """
@@ -372,21 +392,43 @@ class Configuration(services.Configuration):
                 # Nothing to do
                 return
 
-            # Update status
+            updated = self.__updated
+            pid = self.__pid
+
+            error: Exception | None = None
+            try:
+                # Remove the file while still holding the lock and before
+                # flagging this configuration as deleted: as long as the file
+                # is there, a lookup must find this object, else it would
+                # reload the file and give back a duplicate configuration
+                self.__persistence.delete(pid)
+            except Exception as ex:  # noqa: BLE001
+                # The deletion goes on: the notification and the clean up below
+                # must happen anyway, else the services would keep working with
+                # a deleted configuration. The error is given back to the
+                # caller once everything else is done
+                error = ex
+
+            # Update status: this configuration is now hidden from its users
+            # and its PID can be taken by a new one
             self.__deleted = True
 
-            # Notify ConfigurationAdmin, notify services only if the
-            # configuration had been updated before
-            cast(ConfigurationAdmin, self.__config_admin)._delete(self, self.__updated, directory_updated)
+        # Notify ConfigurationAdmin outside of the lock: notification is
+        # synchronous and services only if the configuration had been
+        # updated before; the callback can call back into this or another
+        # Configuration object
+        cast(ConfigurationAdmin, self.__config_admin)._delete(self, updated, directory_updated)
 
-            # Remove the file
-            self.__persistence.delete(self.__pid)
-
+        with self.__lock:
             # Clean up
             if self.__properties:
                 self.__properties.clear()
 
             self.__pid = ""
+
+        if error is not None:
+            # Tell the caller that the persisted configuration is still there
+            raise error
 
     def matches(self, ldap_filter: ldapfilter.LdapFilterOrCriteria | None) -> bool:
         """
@@ -444,9 +486,25 @@ class ConfigurationDirectory(IConfigurationAdminDirectory):
 
         :param pid: PID of the configuration
         :return: The configuration with the given PID
-        :raise KeyError: Unknown PID
+        :raise KeyError: Unknown or deleted PID
         """
-        return self.__configurations[pid]
+        return self.__get_alive(pid)
+
+    def __get_alive(self, pid: str) -> Configuration:
+        """
+        Retrieves the configuration with the given PID, ignoring the ones which
+        are being deleted: their PID is still reserved, as their file is being
+        removed, but they are already gone for their users
+
+        :param pid: PID of the configuration
+        :return: The configuration with the given PID
+        :raise KeyError: Unknown or deleted PID
+        """
+        configuration = self.__configurations[pid]
+        if configuration.is_deleted():
+            raise KeyError(f"Deleted configuration: {pid}")
+
+        return configuration
 
     def get_factory_configurations(self, factory_pid: str) -> set[Configuration]:
         """
@@ -455,7 +513,8 @@ class ConfigurationDirectory(IConfigurationAdminDirectory):
         :param factory_pid: A factory PID
         :return: The set of matching configuration
         """
-        return set(self.__factories.get(factory_pid, []))
+        with self.__lock:
+            return set(self.__factories.get(factory_pid, []))
 
     def list_configurations(
         self, ldap_filter: None | str | ldapfilter.LdapFilterOrCriteria = None
@@ -468,7 +527,8 @@ class ConfigurationDirectory(IConfigurationAdminDirectory):
         :raise ValueError: Invalid LDAP filter
         """
         if not ldap_filter:
-            return set(self.__configurations.values())
+            # matches() already ignores the deleted configurations
+            return {config for config in self.__configurations.values() if not config.is_deleted()}
 
         # Using an LDAP filter
         ldap_filter = ldapfilter.get_ldap_filter(ldap_filter)
@@ -493,8 +553,9 @@ class ConfigurationDirectory(IConfigurationAdminDirectory):
         :raise ValueError: Invalid PID or persistence
         """
         with self.__lock:
-            if pid in self.__configurations:
-                raise KeyError("Already known configuration: {pid}")
+            known = self.__configurations.get(pid)
+            if known is not None and not known.is_deleted():
+                raise KeyError(f"Already known configuration: {pid}")
             elif not pid:
                 raise ValueError("Configuration with an empty PID")
             elif pid in self.__factories:
@@ -524,8 +585,13 @@ class ConfigurationDirectory(IConfigurationAdminDirectory):
         :raise IOError: Error writing down the configuration
         """
         with self.__lock:
-            # Update properties directly
-            self.__configurations[pid].update(properties)
+            # Look for the configuration (raises KeyError if unknown)
+            configuration = self.__get_alive(pid)
+
+        # Update outside of the lock: the managed services are notified in this
+        # thread and can call back into the directory, which uses a
+        # non-reentrant lock
+        configuration.update(properties)
 
     def delete(self, pid: str) -> None:
         """
@@ -536,23 +602,41 @@ class ConfigurationDirectory(IConfigurationAdminDirectory):
         :raise IOError: Error deleting the configuration file
         """
         with self.__lock:
-            # Remove from the configuration dictionary
-            config = self.__configurations.pop(pid)
+            # Look up the configuration (raises KeyError if unknown); do not
+            # remove it from the dictionary yet. A configuration which is
+            # already being deleted must be found here: this method is called
+            # back by Configuration.delete() itself
+            config = self.__configurations[pid]
 
-            # Remove from the factory PIDs set
-            factory_pid = config.get_factory_pid()
-            if factory_pid:
-                try:
-                    factory_configs = self.__factories[factory_pid]
-                    factory_configs.remove(config)
-                    if not factory_configs:
-                        del self.__factories[factory_pid]
-                except KeyError:
-                    # Wasn't a known factory configuration
-                    _logger.warning("Trying to delete configuration from unknown factory %s", factory_pid)
-
-            # Delete the configuration object
+        try:
+            # Delete the configuration object outside of the lock (see
+            # update()): notification is synchronous and can call back into the
+            # directory
             config.delete(True)
+        finally:
+            # Clean up even if the persistence service failed to remove the
+            # stored configuration: the configuration object is deleted anyway
+            with self.__lock:
+                # Now that teardown (including the persisted file removal) is
+                # complete, forget about this configuration. Removing it
+                # earlier would let a lookup treat the PID as "unknown to the
+                # directory but still persisted" and recreate a duplicate
+                # configuration. A new configuration can have taken this PID in
+                # the meantime: it must be kept
+                if self.__configurations.get(pid) is config:
+                    del self.__configurations[pid]
+
+                # Remove from the factory PIDs set
+                factory_pid = config.get_factory_pid()
+                if factory_pid:
+                    try:
+                        factory_configs = self.__factories[factory_pid]
+                        factory_configs.discard(config)
+                        if not factory_configs:
+                            del self.__factories[factory_pid]
+                    except KeyError:
+                        # Wasn't a known factory configuration
+                        _logger.warning("Trying to delete configuration from unknown factory %s", factory_pid)
 
 
 # ------------------------------------------------------------------------------
@@ -643,10 +727,13 @@ class ConfigurationAdmin(services.IConfigurationAdmin):
 
             # Validation flag
             self.__validated = True
+            set_up = self._controller
 
-            # If the controller is on, set up the main service
-            if self._controller:
-                self.__set_up()
+        # If the controller is on, set up the main service. This is done
+        # outside the lock: the notification of the services is synchronous
+        # and can call back into ConfigurationAdmin
+        if set_up:
+            self.__set_up()
 
     @Invalidate
     def _invalidate(self, _: "BundleContext") -> None:
@@ -769,8 +856,6 @@ class ConfigurationAdmin(services.IConfigurationAdmin):
         """
         Updates the managed services for the given PIDs.
 
-        This method should be called inside a locked block.
-
         :param pids: List of PIDs of configurations to load & update
         """
         for pid in pids:
@@ -819,8 +904,10 @@ class ConfigurationAdmin(services.IConfigurationAdmin):
         :param pid: Service Persistent ID
         :param svc: Managed service
         """
-        configuration = self.get_configuration(pid)
-        if configuration.is_valid():
+        # Don't use get_configuration(): it would create an empty configuration
+        # for a service which has never been configured
+        configuration = self.__find_configuration(pid)
+        if configuration is not None and configuration.is_valid():
             # Valid configuration found, update the service
             assert self._pool is not None
             self._pool.enqueue(svc.updated, configuration.get_properties())
@@ -904,30 +991,28 @@ class ConfigurationAdmin(services.IConfigurationAdmin):
         :param configuration: The updated configuration
         """
         with self.__lock:
-            future = None
-            assert self._pool is not None
-
             # Get configuration data
             factory_pid = configuration.get_factory_pid()
             pid = configuration.get_pid()
             properties = configuration.get_properties()
 
+            factories: list[services.IManagedServiceFactory] = []
+            managed: list[services.IManagedService] = []
             if factory_pid:
                 # Get the associated factories
                 factories = self.__get_matching_factories(factory_pid)
-                if factories:
-                    # Call them from the pool
-                    future = self._pool.enqueue(self.__notify_factories, factories, pid, properties)
             else:
-                # Called corresponding managed services
-                managed = self.__get_matching_services(configuration.get_pid())
-                if managed:
-                    # Call them from the pool
-                    future = self._pool.enqueue(self.__notify_services, managed, properties)
+                # Get the corresponding managed services
+                managed = self.__get_matching_services(pid)
 
-        if future is not None:
-            # Wait for the end of the notification, outside the lock
-            future.result()
+        # Notify the services in the calling thread, outside the lock: giving
+        # the notification to the pool and waiting for its result would block
+        # forever if the caller holds a lock the notified service needs, e.g.
+        # the iPOPO instances registry
+        if factories:
+            self.__notify_factories(factories, pid, properties)
+        elif managed:
+            self.__notify_services(managed, properties)
 
     def _delete(self, configuration: Configuration, notify_services: bool, directory_updated: bool) -> None:
         """
@@ -940,9 +1025,6 @@ class ConfigurationAdmin(services.IConfigurationAdmin):
         :param directory_updated: If True, do not update the directory
         """
         with self.__lock:
-            future = None
-            assert self._pool is not None
-
             factory_pid = configuration.get_factory_pid()
             pid = configuration.get_pid()
 
@@ -950,23 +1032,22 @@ class ConfigurationAdmin(services.IConfigurationAdmin):
             if not directory_updated:
                 self._directory.delete(pid)
 
+            factories: list[services.IManagedServiceFactory] = []
+            managed: list[services.IManagedService] = []
             if notify_services:
                 if factory_pid:
                     # Get the associated factories
                     factories = self.__get_matching_factories(factory_pid)
-                    if factories:
-                        # Call them from the pool
-                        future = self._pool.enqueue(self.__notify_factories_delete, factories, pid)
                 else:
-                    # Called corresponding managed services
+                    # Get the corresponding managed services
                     managed = self.__get_matching_services(pid)
-                    if managed:
-                        # Call them from the pool
-                        future = self._pool.enqueue(self.__notify_services, managed, None)
 
-        if future is not None:
-            # Wait for the end of the notification, outside the lock
-            future.result()
+        # Notify the services in the calling thread, outside the lock (see
+        # _update() for the reason)
+        if factories:
+            self.__notify_factories_delete(factories, pid)
+        elif managed:
+            self.__notify_services(managed, None)
 
     def create_factory_configuration(self, factory_pid: str) -> services.Configuration:
         """
@@ -996,12 +1077,13 @@ class ConfigurationAdmin(services.IConfigurationAdmin):
             # Create the new factory configuration
             return self._directory.add(pid, None, self._persistences[0], factory_pid)
 
-    def get_configuration(self, pid: str) -> services.Configuration:
+    def __find_configuration(self, pid: str) -> services.Configuration | None:
         """
-        Get an existing Configuration object from the persistent store, or
-        create a new Configuration object.
+        Looks for an existing configuration, in the directory then in the
+        persistence services, without creating one
 
-        :param pid: PID of the factory
+        :param pid: PID of a configuration
+        :return: The configuration with that PID, None if there is none
         :raise IOError: File not found/readable
         """
         with self.__lock:
@@ -1014,18 +1096,30 @@ class ConfigurationAdmin(services.IConfigurationAdmin):
 
             for persistence in self._persistences[:]:
                 if persistence.exists(pid):
-                    # Load first existing one
+                    # Load the first existing one
                     properties = persistence.load(pid)
-                    break
-            else:
-                # New configuration, with the best ranked persistence
-                properties = {}
-                persistence = self._persistences[0]
 
-            # Take care of stored factory PID
-            factory_pid = properties.get(services.CONFIG_PROP_FACTORY_PID)
+                    # Take care of stored factory PID
+                    factory_pid = properties.get(services.CONFIG_PROP_FACTORY_PID)
+                    return self._directory.add(pid, properties, persistence, factory_pid)
 
-            return self._directory.add(pid, properties, persistence, factory_pid)
+            return None
+
+    def get_configuration(self, pid: str) -> services.Configuration:
+        """
+        Get an existing Configuration object from the persistent store, or
+        create a new Configuration object.
+
+        :param pid: PID of the factory
+        :raise IOError: File not found/readable
+        """
+        with self.__lock:
+            configuration = self.__find_configuration(pid)
+            if configuration is not None:
+                return configuration
+
+            # New configuration, with the best ranked persistence
+            return self._directory.add(pid, {}, self._persistences[0])
 
     def list_configurations(
         self, ldap_filter: None | str | ldapfilter.LdapFilterOrCriteria = None
@@ -1287,8 +1381,13 @@ class JsonPersistence(services.IConfigurationAdminPersistence):
                         # Update the configuration
                         self._directory.update(pid, properties)
                     except KeyError:
-                        # Configuration does not exist yet, create it
-                        self._directory.add(pid, properties, self)
+                        # Configuration does not exist yet: create it empty,
+                        # then update it, as the creation alone doesn't notify
+                        # the managed services. The factory PID must be given
+                        # at creation, else the configuration would never
+                        # reach the managed service factories
+                        factory_pid = properties.get(services.CONFIG_PROP_FACTORY_PID)
+                        self._directory.add(pid, None, self, factory_pid).update(properties)
                 except (OSError, KeyError, ValueError) as ex:
                     # Log other errors
                     _logger.error("Error updating %s: %s", pid, ex)

--- a/pelix/services/fileinstall.py
+++ b/pelix/services/fileinstall.py
@@ -121,19 +121,22 @@ class FileInstall(services.FileInstall):
         """
         with self.__lock:
             # Stop all threads
-            for event in set(self.__stoppers.values()):
-                event.set()
-
-            # Wait for them
-            for thread in set(self.__threads.values()):
-                thread.join()
-
-            # Stop the task pool
-            self.__pool.stop()
+            stoppers = set(self.__stoppers.values())
+            threads = set(self.__threads.values())
 
             # Clean up
             self.__stoppers.clear()
             self.__threads.clear()
+
+        for event in stoppers:
+            event.set()
+
+        # Wait for the threads and stop the pool outside the lock: a
+        # notification being sent needs that lock to reach its listeners
+        for thread in threads:
+            thread.join()
+
+        self.__pool.stop()
 
     @BindField("_listeners")
     def _bind_listener(

--- a/samples/configadmin/__init__.py
+++ b/samples/configadmin/__init__.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+ConfigurationAdmin sample package: contains the components managed by
+ConfigurationAdmin
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"

--- a/samples/configadmin/greeter.py
+++ b/samples/configadmin/greeter.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Components managed by ConfigurationAdmin
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+:version: 1.0.0
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import logging
+
+from pelix.framework import BundleContext
+from pelix.ipopo.decorators import (
+    ComponentFactory,
+    Instantiate,
+    Invalidate,
+    Property,
+    RequiresConfiguration,
+    Validate,
+)
+
+# ------------------------------------------------------------------------------
+
+# Module version
+__version_info__ = (1, 0, 0)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+# ------------------------------------------------------------------------------
+
+FACTORY_GREETER = "sample-greeter-factory"
+""" Name of the factory instantiated from ConfigurationAdmin """
+
+PID_BANNER = "sample.banner"
+""" PID of the configuration of the banner component """
+
+_logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------------------
+
+
+@ComponentFactory(FACTORY_GREETER)
+@Property("_name", "name", "world")
+@Property("_language", "language", "en")
+class Greeter:
+    """
+    Component instantiated by ConfigurationAdmin: each factory configuration
+    of the "pelix.ipopo.component" PID naming this factory creates one of them
+    """
+
+    _name: str
+    _language: str
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        """
+        Component validated
+        """
+        _logger.info("%s, %s!", "Bonjour" if self._language == "fr" else "Hello", self._name)
+
+    @Invalidate
+    def invalidate(self, _: BundleContext) -> None:
+        """
+        Component invalidated
+        """
+        _logger.info("Goodbye, %s!", self._name)
+
+
+@ComponentFactory("sample-banner-factory")
+@Property("_text", "text", "<no banner>")
+@RequiresConfiguration(PID_BANNER)
+@Instantiate("sample-banner")
+class Banner:
+    """
+    Component which waits for its configuration before being validated
+    """
+
+    _text: str
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        """
+        Component validated
+        """
+        _logger.info("Banner: %s", self._text)

--- a/samples/run_configadmin.py
+++ b/samples/run_configadmin.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Runs a framework where components are managed by ConfigurationAdmin
+
+Sample usage::
+
+   % python samples/run_configadmin.py
+   ** Pelix Shell prompt **
+   $ config.create pelix.ipopo.component ipopo.factory.name=sample-greeter-factory \
+         instance.name=greeter-fr name=Thomas language=fr
+   New configuration: pelix.ipopo.component-...
+   INFO:samples.configadmin.greeter:Bonjour, Thomas!
+   $ config.delete pelix.ipopo.component-...
+   INFO:samples.configadmin.greeter:Goodbye, Thomas!
+
+The "sample-banner" component stays invalid until its configuration exists::
+
+   $ config.update sample.banner text=Hello
+   INFO:samples.configadmin.greeter:Banner: Hello
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+:version: 1.0.0
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import pelix.framework
+
+# ------------------------------------------------------------------------------
+
+# Module version
+__version_info__ = (1, 0, 0)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+# ------------------------------------------------------------------------------
+
+
+def main() -> None:
+    """
+    Runs the framework
+    """
+    fw = pelix.framework.create_framework(
+        (
+            "pelix.ipopo.core",
+            "pelix.ipopo.waiting",
+            # ConfigurationAdmin and its bridge to iPOPO
+            "pelix.services.configadmin",
+            "pelix.ipopo.handlers.configadmin",
+            "pelix.ipopo.configadmin",
+            # Shell, to play with the configurations
+            "pelix.shell.core",
+            "pelix.shell.ipopo",
+            "pelix.shell.configadmin",
+            "pelix.shell.console",
+            # Sample bundle
+            "samples.configadmin.greeter",
+        )
+    )
+
+    # Start the framework and wait for it to stop
+    fw.start()
+    fw.wait_for_stop()
+
+
+if __name__ == "__main__":
+    # Configure the logging package
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+
+    # Run the sample
+    main()

--- a/tests/ipopo/configadmin_bundle.py
+++ b/tests/ipopo/configadmin_bundle.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Bundle defining components managed by ConfigurationAdmin
+
+:author: Thomas Calmant
+"""
+
+from pelix.constants import SERVICE_PID
+from pelix.framework import BundleContext
+from pelix.ipopo.constants import UPDATE_POLICY_RESTART
+from pelix.ipopo.decorators import (
+    ComponentFactory,
+    HiddenProperty,
+    Instantiate,
+    Invalidate,
+    Property,
+    Provides,
+    RequiresConfiguration,
+    Validate,
+)
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+FACTORY_BASIC = "ipopo.tests.configadmin.basic"
+FACTORY_PID = "ipopo.tests.configadmin.pid"
+FACTORY_GATED = "ipopo.tests.configadmin.gated"
+FACTORY_OPTIONAL = "ipopo.tests.configadmin.optional"
+FACTORY_OWN_PID = "ipopo.tests.configadmin.own_pid"
+FACTORY_RESTART = "ipopo.tests.configadmin.restart"
+FACTORY_NO_PID = "ipopo.tests.configadmin.no_pid"
+FACTORY_HIDDEN = "ipopo.tests.configadmin.hidden"
+FACTORY_UNDECLARED_PID = "ipopo.tests.configadmin.undeclared_pid"
+FACTORY_UNSET_PID = "ipopo.tests.configadmin.unset_pid"
+
+SPEC_BASIC = "ipopo.tests.configadmin.spec"
+SPEC_UNDECLARED_PID = "ipopo.tests.configadmin.undeclared.spec"
+
+PID_INSTANCE = "test.ipopo.ca.instance"
+PID_GATED = "test.ipopo.ca.gated"
+PID_OPTIONAL = "test.ipopo.ca.optional"
+PID_OWN = "test.ipopo.ca.own"
+PID_RESTART = "test.ipopo.ca.restart"
+PID_HIDDEN = "test.ipopo.ca.hidden"
+PID_UNDECLARED = "test.ipopo.ca.undeclared"
+
+# ------------------------------------------------------------------------------
+
+
+@ComponentFactory(FACTORY_BASIC)
+@Provides(SPEC_BASIC)
+@Property("_name", "name", "default")
+class Basic:
+    """
+    Component instantiated from a factory configuration
+    """
+
+    _name: str
+
+    def __init__(self) -> None:
+        self.validated = 0
+        self.invalidated = 0
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        self.validated += 1
+
+    @Invalidate
+    def invalidate(self, _: BundleContext) -> None:
+        self.invalidated += 1
+
+
+@ComponentFactory(FACTORY_PID)
+@Property("_name", "name", "default")
+@Property("_pid", SERVICE_PID, PID_INSTANCE)
+@Instantiate("configadmin-pid")
+class WithPid:
+    """
+    Component declaring its own configuration PID
+    """
+
+    _name: str
+    _pid: str
+
+    def __init__(self) -> None:
+        self.validated = 0
+        self.invalidated = 0
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        self.validated += 1
+
+    @Invalidate
+    def invalidate(self, _: BundleContext) -> None:
+        self.invalidated += 1
+
+
+@ComponentFactory(FACTORY_GATED)
+@Property("_name", "name", "default")
+@RequiresConfiguration(PID_GATED)
+@Instantiate("configadmin-gated")
+class Gated:
+    """
+    Component which requires a configuration to be validated
+    """
+
+    _name: str
+
+    def __init__(self) -> None:
+        self.validated = 0
+        self.invalidated = 0
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        self.validated += 1
+
+    @Invalidate
+    def invalidate(self, _: BundleContext) -> None:
+        self.invalidated += 1
+
+
+@ComponentFactory(FACTORY_OPTIONAL)
+@Property("_name", "name", "default")
+@RequiresConfiguration(PID_OPTIONAL, optional=True)
+@Instantiate("configadmin-optional")
+class Optional:
+    """
+    Component which uses a configuration if there is one
+    """
+
+    _name: str
+
+    def __init__(self) -> None:
+        self.validated = 0
+        self.invalidated = 0
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        self.validated += 1
+
+    @Invalidate
+    def invalidate(self, _: BundleContext) -> None:
+        self.invalidated += 1
+
+
+@ComponentFactory(FACTORY_OWN_PID)
+@Property("_name", "name", "default")
+@Property("_pid", SERVICE_PID)
+@RequiresConfiguration()
+@Instantiate("configadmin-own-pid", {SERVICE_PID: PID_OWN})
+class OwnPid:
+    """
+    Component which gives the PID of its configuration in its properties
+    """
+
+    _name: str
+    _pid: str
+
+    def __init__(self) -> None:
+        self.validated = 0
+        self.invalidated = 0
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        self.validated += 1
+
+    @Invalidate
+    def invalidate(self, _: BundleContext) -> None:
+        self.invalidated += 1
+
+
+@ComponentFactory(FACTORY_RESTART)
+@Property("_name", "name", "default")
+@RequiresConfiguration(PID_RESTART, update_policy=UPDATE_POLICY_RESTART)
+@Instantiate("configadmin-restart")
+class Restarted:
+    """
+    Component invalidated then validated again on each configuration update
+    """
+
+    _name: str
+
+    def __init__(self) -> None:
+        self.validated = 0
+        self.invalidated = 0
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        self.validated += 1
+
+    @Invalidate
+    def invalidate(self, _: BundleContext) -> None:
+        self.invalidated += 1
+
+
+@ComponentFactory(FACTORY_NO_PID)
+@Property("_name", "name", "default")
+@RequiresConfiguration()
+@Instantiate("configadmin-no-pid")
+class NoPid:
+    """
+    Component which requires a configuration but gives no PID at all
+    """
+
+    _name: str
+
+    def __init__(self) -> None:
+        self.validated = 0
+        self.invalidated = 0
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        self.validated += 1
+
+    @Invalidate
+    def invalidate(self, _: BundleContext) -> None:
+        self.invalidated += 1
+
+
+@ComponentFactory(FACTORY_HIDDEN)
+@Property("_name", "name", "default")
+@HiddenProperty("_secret", "secret", "declared-secret")
+@Property("_pid", SERVICE_PID, PID_HIDDEN)
+@Instantiate("configadmin-hidden")
+class Hidden:
+    """
+    Component with a hidden property, which a configuration must not modify
+    """
+
+    _name: str
+    _secret: str
+    _pid: str
+
+    def __init__(self) -> None:
+        self.validated = 0
+        self.invalidated = 0
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        self.validated += 1
+
+    @Invalidate
+    def invalidate(self, _: BundleContext) -> None:
+        self.invalidated += 1
+
+
+@ComponentFactory(FACTORY_UNDECLARED_PID)
+@Provides(SPEC_UNDECLARED_PID)
+@Property("_name", "name", "default")
+@Instantiate("configadmin-undeclared-pid", {SERVICE_PID: PID_UNDECLARED})
+class UndeclaredPid:
+    """
+    Component whose configuration PID is given at instantiation, without any
+    matching ``@Property`` declaration: the factory doesn't know that value
+    """
+
+    _name: str
+
+    def __init__(self) -> None:
+        self.validated = 0
+        self.invalidated = 0
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        self.validated += 1
+
+    @Invalidate
+    def invalidate(self, _: BundleContext) -> None:
+        self.invalidated += 1
+
+
+@ComponentFactory(FACTORY_UNSET_PID)
+@Property("_name", "name", "default")
+@Property("_pid", SERVICE_PID)
+@Instantiate("configadmin-unset-pid")
+class UnsetPid:
+    """
+    Component which declares a ``service.pid`` property but is instantiated
+    without giving it a value: it must not follow any configuration
+    """
+
+    _name: str
+    _pid: str
+
+    def __init__(self) -> None:
+        self.validated = 0
+        self.invalidated = 0
+
+    @Validate
+    def validate(self, _: BundleContext) -> None:
+        self.validated += 1
+
+    @Invalidate
+    def invalidate(self, _: BundleContext) -> None:
+        self.invalidated += 1

--- a/tests/ipopo/test_configadmin.py
+++ b/tests/ipopo/test_configadmin.py
@@ -1,0 +1,965 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests the bridge between ConfigurationAdmin and iPOPO
+
+:author: Thomas Calmant
+"""
+
+import json
+import os
+import shutil
+import threading
+import time
+import unittest
+from typing import Any
+
+import pelix.framework
+from pelix import services
+from pelix.constants import SERVICE_PID
+from pelix.ipopo.constants import (
+    IPOPO_CONFIG_FACTORY_NAME,
+    IPOPO_CONFIG_UPDATE_POLICY,
+    IPOPO_CONFIGADMIN_FACTORY_PID,
+    IPOPO_INSTANCE_NAME,
+    UPDATE_POLICY_RESTART,
+    IPopoService,
+    IPopoWaitingList,
+    use_ipopo,
+)
+from tests.ipopo.configadmin_bundle import (
+    FACTORY_BASIC,
+    PID_GATED,
+    PID_HIDDEN,
+    PID_INSTANCE,
+    PID_OPTIONAL,
+    PID_OWN,
+    PID_RESTART,
+    PID_UNDECLARED,
+    SPEC_BASIC,
+    SPEC_UNDECLARED_PID,
+)
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Folder of the configurations of the tests
+conf_folder = os.path.join(os.path.dirname(__file__), "conf")
+
+# Bundles required to run the bridge
+BRIDGE_BUNDLES = (
+    "pelix.ipopo.core",
+    "pelix.ipopo.waiting",
+    "pelix.ipopo.handlers.configadmin",
+    "pelix.services.configadmin",
+    "pelix.ipopo.configadmin",
+)
+
+# ------------------------------------------------------------------------------
+
+
+class ConfigAdminBridgeTest(unittest.TestCase):
+    """
+    Tests the components managed by ConfigurationAdmin
+    """
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Removes the configuration folder created by the tests
+        """
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+    def setUp(self) -> None:
+        """
+        Starts a framework with the ConfigurationAdmin bridge
+        """
+        # Each test starts with an empty set of configurations
+        shutil.rmtree(conf_folder, ignore_errors=True)
+        self.start_framework()
+
+    def tearDown(self) -> None:
+        """
+        Cleans up the framework and the stored configurations
+        """
+        self.stop_framework()
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+    def start_framework(self) -> None:
+        """
+        Starts a framework, keeping the configurations already stored
+        """
+        self.framework = pelix.framework.create_framework(
+            BRIDGE_BUNDLES, {"configuration.folder": conf_folder}
+        )
+        self.addCleanup(self.framework.delete, True)
+        self.framework.start()
+
+        self.context = self.framework.get_bundle_context()
+        config_ref = self.context.get_service_reference(services.IConfigurationAdmin)
+        assert config_ref is not None
+        self.config_ref = config_ref
+        self.config = self.context.get_service(config_ref)
+
+    def stop_framework(self) -> None:
+        """
+        Stops the framework, keeping the stored configurations
+        """
+        self.context.unget_service(self.config_ref)
+        pelix.framework.FrameworkFactory.delete_framework()
+
+    @staticmethod
+    def pause() -> None:
+        """
+        Small pause to let the task pool notify the services
+        """
+        time.sleep(0.2)
+
+    def install_test_bundle(self) -> pelix.framework.Bundle:
+        """
+        Installs and starts the bundle defining the test components
+        """
+        bundle = self.context.install_bundle("tests.ipopo.configadmin_bundle")
+        bundle.start()
+        return bundle
+
+    def get_ipopo(self) -> IPopoService:
+        """
+        Returns the iPOPO service
+        """
+        ref = self.context.get_service_reference(IPopoService)
+        assert ref is not None
+        return self.context.get_service(ref)
+
+    def get_instance(self, name: str) -> Any:
+        """
+        Returns the component instance with the given name
+        """
+        with use_ipopo(self.context) as ipopo:
+            return ipopo.get_instance(name)
+
+    def get_property(self, name: str, key: str) -> Any:
+        """
+        Returns a property of the component with the given name
+        """
+        with use_ipopo(self.context) as ipopo:
+            return ipopo.get_instance_details(name)["properties"].get(key)
+
+    def is_running(self, name: str) -> bool:
+        """
+        Checks if a component with the given name is instantiated
+        """
+        with use_ipopo(self.context) as ipopo:
+            return ipopo.is_registered_instance(name)
+
+    def make_component(self, instance_name: str, **properties: Any) -> services.Configuration:
+        """
+        Creates a factory configuration describing a component of the "basic"
+        test factory
+
+        :param instance_name: Name of the component instance
+        :param properties: Additional component properties
+        :return: The new configuration
+        """
+        config = self.config.create_factory_configuration(IPOPO_CONFIGADMIN_FACTORY_PID)
+        config.update(
+            {
+                IPOPO_CONFIG_FACTORY_NAME: FACTORY_BASIC,
+                IPOPO_INSTANCE_NAME: instance_name,
+                **properties,
+            }
+        )
+        self.pause()
+        return config
+
+    def testCreateDelete(self) -> None:
+        """
+        A factory configuration must create a component, its deletion must kill it
+        """
+        self.install_test_bundle()
+        self.assertFalse(self.is_running("test-1"))
+
+        config = self.make_component("test-1", name="hello")
+        self.assertTrue(self.is_running("test-1"))
+        self.assertEqual(self.get_property("test-1", "name"), "hello")
+        self.assertEqual(self.get_instance("test-1").validated, 1)
+
+        # The component provides its service
+        self.assertIsNotNone(self.context.get_service_reference(SPEC_BASIC))
+
+        config.delete()
+        self.pause()
+        self.assertFalse(self.is_running("test-1"))
+        self.assertIsNone(self.context.get_service_reference(SPEC_BASIC))
+
+    def testDefaultInstanceName(self) -> None:
+        """
+        Without an instance name, the component is named after the configuration PID
+        """
+        self.install_test_bundle()
+
+        config = self.config.create_factory_configuration(IPOPO_CONFIGADMIN_FACTORY_PID)
+        config.update({IPOPO_CONFIG_FACTORY_NAME: FACTORY_BASIC})
+        self.pause()
+
+        self.assertTrue(self.is_running(config.get_pid()))
+
+    def testMissingFactoryName(self) -> None:
+        """
+        A configuration without the name of a factory must be ignored
+        """
+        self.install_test_bundle()
+
+        config = self.config.create_factory_configuration(IPOPO_CONFIGADMIN_FACTORY_PID)
+        config.update({IPOPO_INSTANCE_NAME: "test-no-factory", "name": "hello"})
+        self.pause()
+
+        self.assertFalse(self.is_running("test-no-factory"))
+
+    def testFactoryNameRemoved(self) -> None:
+        """
+        An update dropping the name of the factory must kill the component
+        """
+        self.install_test_bundle()
+        config = self.make_component("test-lost-factory", name="hello")
+        self.assertTrue(self.is_running("test-lost-factory"))
+
+        # An update replaces the whole set of properties: the caller can forget
+        # to give the name of the factory back
+        config.update({IPOPO_INSTANCE_NAME: "test-lost-factory", "name": "world"})
+        self.pause()
+
+        self.assertFalse(self.is_running("test-lost-factory"))
+
+    def testUpdateInPlace(self) -> None:
+        """
+        An update must reconfigure the component without restarting it
+        """
+        self.install_test_bundle()
+        config = self.make_component("test-2", name="hello")
+
+        instance = self.get_instance("test-2")
+        self.assertEqual(instance.validated, 1)
+
+        properties = config.get_properties()
+        assert properties is not None
+        properties["name"] = "world"
+        config.update(properties)
+        self.pause()
+
+        # Same instance, updated property
+        self.assertIs(self.get_instance("test-2"), instance)
+        self.assertEqual(instance.validated, 1)
+        self.assertEqual(instance._name, "world")
+        self.assertEqual(self.get_property("test-2", "name"), "world")
+
+        # The property of the provided service follows
+        svc_ref = self.context.get_service_reference(SPEC_BASIC, "(instance.name=test-2)")
+        assert svc_ref is not None
+        self.assertEqual(svc_ref.get_property("name"), "world")
+
+    def testUpdateRestartPolicy(self) -> None:
+        """
+        With the "restart" policy, the component must be killed and created again
+        """
+        self.install_test_bundle()
+        config = self.make_component(
+            "test-3", name="hello", **{IPOPO_CONFIG_UPDATE_POLICY: UPDATE_POLICY_RESTART}
+        )
+
+        instance = self.get_instance("test-3")
+
+        # The directives of the bridge are not component properties
+        self.assertIsNone(self.get_property("test-3", IPOPO_CONFIG_UPDATE_POLICY))
+        self.assertIsNone(self.get_property("test-3", IPOPO_CONFIG_FACTORY_NAME))
+
+        properties = config.get_properties()
+        assert properties is not None
+        properties["name"] = "world"
+        config.update(properties)
+        self.pause()
+
+        new_instance = self.get_instance("test-3")
+        self.assertIsNot(new_instance, instance)
+        self.assertEqual(instance.invalidated, 1)
+        self.assertEqual(new_instance.validated, 1)
+        self.assertEqual(new_instance._name, "world")
+
+    def testUpdateRenameInstance(self) -> None:
+        """
+        Changing the name of the instance must kill the old component
+        """
+        self.install_test_bundle()
+        config = self.make_component("test-4", name="hello")
+
+        properties = config.get_properties()
+        assert properties is not None
+        properties[IPOPO_INSTANCE_NAME] = "test-4-bis"
+        config.update(properties)
+        self.pause()
+
+        self.assertFalse(self.is_running("test-4"))
+        self.assertTrue(self.is_running("test-4-bis"))
+
+    def testRemovedPropertyGoesBackToDefault(self) -> None:
+        """
+        A property removed from the configuration must go back to its declared value
+        """
+        self.install_test_bundle()
+        config = self.make_component("test-5", name="hello")
+        self.assertEqual(self.get_property("test-5", "name"), "hello")
+
+        properties = config.get_properties()
+        assert properties is not None
+        del properties["name"]
+        config.update(properties)
+        self.pause()
+
+        self.assertEqual(self.get_property("test-5", "name"), "default")
+
+    def testRemovedPropertyWithoutFactory(self) -> None:
+        """
+        A property removed while the factory is absent must go back to its
+        declared value, not to None
+        """
+        bundle = self.install_test_bundle()
+        config = self.make_component("test-5b", name="hello")
+        self.assertEqual(self.get_property("test-5b", "name"), "hello")
+
+        # The component is killed but stays in the waiting list
+        bundle.stop()
+        self.assertFalse(self.is_running("test-5b"))
+
+        properties = config.get_properties()
+        assert properties is not None
+        del properties["name"]
+        config.update(properties)
+        self.pause()
+
+        # The factory declares the value again when it comes back
+        bundle.start()
+        self.assertTrue(self.is_running("test-5b"))
+        self.assertEqual(self.get_property("test-5b", "name"), "default")
+
+    def testForgottenComponentIsCreatedAgain(self) -> None:
+        """
+        A component removed from the waiting list behind the back of the bridge
+        must be created again by the next update of its configuration
+        """
+        self.install_test_bundle()
+        config = self.make_component("test-5c", name="hello")
+        self.assertTrue(self.is_running("test-5c"))
+
+        # Remove the component from the waiting list, which kills it
+        ref = self.context.get_service_reference(IPopoWaitingList)
+        assert ref is not None
+        self.context.get_service(ref).remove("test-5c")
+        self.assertFalse(self.is_running("test-5c"))
+
+        properties = config.get_properties()
+        assert properties is not None
+        properties["name"] = "world"
+        config.update(properties)
+        self.pause()
+
+        self.assertTrue(self.is_running("test-5c"))
+        self.assertEqual(self.get_property("test-5c", "name"), "world")
+
+    def testDuplicateInstanceName(self) -> None:
+        """
+        A configuration naming an instance which already exists must be
+        rejected, and must not touch the component of the other configuration
+        """
+        self.install_test_bundle()
+        first = self.make_component("test-dup", name="from-first")
+        second = self.make_component("test-dup", name="from-second")
+
+        # The second configuration didn't create anything
+        self.assertTrue(self.is_running("test-dup"))
+        self.assertEqual(self.get_property("test-dup", "name"), "from-first")
+
+        # Updating it must not reconfigure the component of the first one
+        properties = second.get_properties()
+        assert properties is not None
+        properties["name"] = "from-second-updated"
+        second.update(properties)
+        self.pause()
+
+        self.assertEqual(self.get_property("test-dup", "name"), "from-first")
+
+        # Deleting it must not kill the component of the first one
+        second.delete()
+        self.pause()
+
+        self.assertTrue(self.is_running("test-dup"))
+        self.assertEqual(self.get_property("test-dup", "name"), "from-first")
+
+        # The first configuration still drives its component
+        properties = first.get_properties()
+        assert properties is not None
+        properties["name"] = "from-first-updated"
+        first.update(properties)
+        self.pause()
+
+        self.assertEqual(self.get_property("test-dup", "name"), "from-first-updated")
+
+        first.delete()
+        self.pause()
+        self.assertFalse(self.is_running("test-dup"))
+
+    def testConcurrentUpdates(self) -> None:
+        """
+        Two updates of the same configuration must not make the bridge lose
+        the ownership of the component it created
+        """
+        self.install_test_bundle()
+        instantiator = self.get_instance("ipopo-configadmin-instantiator")
+
+        # Deschedule the first instantiation, to force the interleaving of two
+        # updates of the same configuration: ConfigurationAdmin notifies from
+        # a pool of threads
+        original = instantiator._ConfigAdminInstantiator__add
+        calls = []
+
+        def slow_add(config: Any) -> bool:
+            calls.append(config.name)
+            if len(calls) == 1:
+                time.sleep(1)
+            return original(config)
+
+        instantiator._ConfigAdminInstantiator__add = slow_add
+
+        config = self.config.create_factory_configuration(IPOPO_CONFIGADMIN_FACTORY_PID)
+        description = {IPOPO_CONFIG_FACTORY_NAME: FACTORY_BASIC, IPOPO_INSTANCE_NAME: "test-raced"}
+        threads = [
+            threading.Thread(
+                target=instantiator.updated, args=(config.get_pid(), {**description, "name": name})
+            )
+            for name in ("one", "two")
+        ]
+
+        threads[0].start()
+        time.sleep(0.3)
+        threads[1].start()
+        for thread in threads:
+            thread.join()
+
+        self.assertTrue(self.is_running("test-raced"))
+
+        # The last update wins: the first one must not be applied afterwards
+        self.assertEqual(self.get_property("test-raced", "name"), "two")
+
+        # The bridge still owns the component: the deletion of the
+        # configuration must kill it
+        instantiator.deleted(config.get_pid())
+        self.assertFalse(self.is_running("test-raced"), "The component is not managed anymore")
+
+    def testFactoryComesLater(self) -> None:
+        """
+        A configuration naming an unknown factory must wait for it
+        """
+        config = self.make_component("test-6", name="hello")
+        self.assertFalse(self.is_running("test-6"))
+
+        bundle = self.install_test_bundle()
+        self.assertTrue(self.is_running("test-6"))
+        self.assertEqual(self.get_property("test-6", "name"), "hello")
+
+        # Stopping the bundle kills the component, restarting it creates it again
+        bundle.stop()
+        self.assertFalse(self.is_running("test-6"))
+
+        bundle.start()
+        self.assertTrue(self.is_running("test-6"))
+
+        config.delete()
+        self.pause()
+        self.assertFalse(self.is_running("test-6"))
+
+    def testStopBridgeKillsComponents(self) -> None:
+        """
+        Stopping the bridge must kill the components it created
+        """
+        self.install_test_bundle()
+        self.make_component("test-7", name="hello")
+        self.assertTrue(self.is_running("test-7"))
+
+        for bundle in self.context.get_bundles():
+            if bundle.get_symbolic_name() == "pelix.ipopo.configadmin":
+                bundle.stop()
+                break
+        else:
+            self.fail("Bridge bundle not found")
+
+        self.assertFalse(self.is_running("test-7"))
+
+    def testPersistence(self) -> None:
+        """
+        A configuration stored on disk must create its component at the next start
+        """
+        self.install_test_bundle()
+        config = self.make_component("test-8", name="stored")
+        pid = config.get_pid()
+
+        # Restart the framework, keeping the configuration folder
+        self.stop_framework()
+        self.start_framework()
+        self.install_test_bundle()
+        self.pause()
+
+        self.assertTrue(self.is_running("test-8"))
+        self.assertEqual(self.get_property("test-8", "name"), "stored")
+        self.assertEqual(self.config.get_configuration(pid).get_pid(), pid)
+
+
+# ------------------------------------------------------------------------------
+
+
+class ConfigAdminBridgeStartupTest(unittest.TestCase):
+    """
+    Tests the start of the bridge when ConfigurationAdmin notifies it while
+    iPOPO is busy instantiating components
+    """
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Removes the configuration folder created by the tests
+        """
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+    def setUp(self) -> None:
+        """
+        Stores a configuration describing a component
+        """
+        shutil.rmtree(conf_folder, ignore_errors=True)
+        os.makedirs(conf_folder)
+
+        with open(os.path.join(conf_folder, "test-startup.config.js"), "w") as filep:
+            json.dump(
+                {
+                    services.CONFIG_PROP_PID: "test-startup",
+                    services.CONFIG_PROP_FACTORY_PID: IPOPO_CONFIGADMIN_FACTORY_PID,
+                    IPOPO_CONFIG_FACTORY_NAME: FACTORY_BASIC,
+                    IPOPO_INSTANCE_NAME: "test-startup",
+                },
+                filep,
+            )
+
+    def tearDown(self) -> None:
+        """
+        Cleans up the stored configurations
+        """
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+    def testConfigAdminStartedLast(self) -> None:
+        """
+        A stored configuration is given to the bridge while iPOPO is
+        instantiating ConfigurationAdmin: the start must not be blocked
+        """
+        # ConfigurationAdmin is started after the bridge: it notifies it from
+        # inside the instantiation of its own components
+        framework = pelix.framework.create_framework(
+            (
+                "pelix.ipopo.core",
+                "pelix.ipopo.waiting",
+                "pelix.ipopo.handlers.configadmin",
+                "pelix.ipopo.configadmin",
+                "tests.ipopo.configadmin_bundle",
+                "pelix.services.configadmin",
+            ),
+            {"configuration.folder": conf_folder},
+        )
+
+        # Start in another thread: a blocked start would else freeze the tests
+        starter = threading.Thread(target=framework.start, daemon=True)
+        starter.start()
+        starter.join(30)
+        if starter.is_alive():
+            self.fail("The framework start is blocked")
+
+        # The framework is running: it can be deleted safely
+        self.addCleanup(pelix.framework.FrameworkFactory.delete_framework)
+
+        with use_ipopo(framework.get_bundle_context()) as ipopo:
+            self.assertTrue(ipopo.is_registered_instance("test-startup"))
+
+
+# ------------------------------------------------------------------------------
+
+
+class ConfiguredInstanceTest(unittest.TestCase):
+    """
+    Tests the configuration of components which are not created by
+    ConfigurationAdmin
+    """
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Removes the configuration folder created by the tests
+        """
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+    def setUp(self) -> None:
+        """
+        Starts a framework with the ConfigurationAdmin bridge
+        """
+        # Each test starts with an empty set of configurations
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+        self.framework = pelix.framework.create_framework(
+            BRIDGE_BUNDLES, {"configuration.folder": conf_folder}
+        )
+        self.addCleanup(self.framework.delete, True)
+        self.framework.start()
+
+        self.context = self.framework.get_bundle_context()
+        config_ref = self.context.get_service_reference(services.IConfigurationAdmin)
+        assert config_ref is not None
+        self.config_ref = config_ref
+        self.config = self.context.get_service(config_ref)
+
+        self.bundle = self.context.install_bundle("tests.ipopo.configadmin_bundle")
+        self.bundle.start()
+
+    def tearDown(self) -> None:
+        """
+        Cleans up the framework and the stored configurations
+        """
+        self.context.unget_service(self.config_ref)
+        pelix.framework.FrameworkFactory.delete_framework()
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+    @staticmethod
+    def pause() -> None:
+        """
+        Small pause to let the task pool notify the services
+        """
+        time.sleep(0.2)
+
+    def get_instance(self, name: str) -> Any:
+        """
+        Returns the component instance with the given name
+        """
+        with use_ipopo(self.context) as ipopo:
+            return ipopo.get_instance(name)
+
+    def get_state(self, name: str) -> int:
+        """
+        Returns the state of the component with the given name
+        """
+        with use_ipopo(self.context) as ipopo:
+            return ipopo.get_instance_details(name)["state"]
+
+    def testComponentWithPid(self) -> None:
+        """
+        A component declaring a service.pid property must follow the
+        configuration with that PID
+        """
+        instance = self.get_instance("configadmin-pid")
+        self.assertEqual(instance._name, "default")
+        self.assertEqual(instance.validated, 1)
+
+        config = self.config.get_configuration(PID_INSTANCE)
+        config.update({"name": "configured"})
+        self.pause()
+
+        # Updated in place
+        self.assertEqual(instance._name, "configured")
+        self.assertEqual(instance.validated, 1)
+
+        config.delete()
+        self.pause()
+        self.assertEqual(instance._name, "default")
+
+    def testKilledWhileTracked(self) -> None:
+        """
+        A component killed while the bridge reads its properties must not keep
+        a managed service registered
+        """
+        configurator = self.get_instance("ipopo-configadmin-configurator")
+
+        # The component declares no PID: it is not followed when it is created
+        with use_ipopo(self.context) as ipopo:
+            ipopo.instantiate(FACTORY_BASIC, "raced-instance", {})
+
+        def component_pid(factory: str, name: str) -> str:
+            # The component is killed while its properties are read
+            with use_ipopo(self.context) as ipopo:
+                ipopo.kill(name)
+            return "raced-pid"
+
+        configurator._ConfigAdminConfigurator__component_pid = component_pid
+        configurator._ConfigAdminConfigurator__track(FACTORY_BASIC, "raced-instance")
+
+        self.assertNotIn("raced-instance", configurator._registrations)
+        self.assertIsNone(
+            self.context.get_service_reference(services.IManagedService, "(service.pid=raced-pid)")
+        )
+
+    def testRequiresConfiguration(self) -> None:
+        """
+        A component using @RequiresConfiguration must wait for its configuration
+        """
+        from pelix.ipopo.instance import StoredInstance
+
+        instance = self.get_instance("configadmin-gated")
+        self.assertEqual(instance.validated, 0)
+        self.assertEqual(self.get_state("configadmin-gated"), StoredInstance.INVALID)
+
+        config = self.config.get_configuration(PID_GATED)
+        config.update({"name": "configured"})
+        self.pause()
+
+        self.assertEqual(instance.validated, 1)
+        self.assertEqual(instance._name, "configured")
+        self.assertEqual(self.get_state("configadmin-gated"), StoredInstance.VALID)
+
+        config.delete()
+        self.pause()
+
+        self.assertEqual(instance.invalidated, 1)
+        self.assertEqual(instance._name, "default")
+        self.assertEqual(self.get_state("configadmin-gated"), StoredInstance.INVALID)
+
+    def testRemovedPropertyGoesBackToDefault(self) -> None:
+        """
+        A property removed from the configuration of a gated component must go
+        back to its declared value
+        """
+        instance = self.get_instance("configadmin-gated")
+
+        config = self.config.get_configuration(PID_GATED)
+        config.update({"name": "configured", "extra": 42})
+        self.pause()
+        self.assertEqual(instance._name, "configured")
+
+        config.update({"extra": 42})
+        self.pause()
+        self.assertEqual(instance._name, "default")
+
+        # The component is still valid: it still has a configuration
+        self.assertEqual(instance.invalidated, 0)
+
+    def testPidFromProperties(self) -> None:
+        """
+        Without a PID, @RequiresConfiguration must use the service.pid property
+        of the component
+        """
+        instance = self.get_instance("configadmin-own-pid")
+        self.assertEqual(instance.validated, 0)
+
+        config = self.config.get_configuration(PID_OWN)
+        config.update({"name": "configured"})
+        self.pause()
+
+        self.assertEqual(instance.validated, 1)
+        self.assertEqual(instance._name, "configured")
+
+    def testOptionalConfiguration(self) -> None:
+        """
+        A component using an optional @RequiresConfiguration must be validated
+        without configuration
+        """
+        instance = self.get_instance("configadmin-optional")
+        self.assertEqual(instance.validated, 1)
+        self.assertEqual(instance._name, "default")
+
+        config = self.config.get_configuration(PID_OPTIONAL)
+        config.update({"name": "configured"})
+        self.pause()
+
+        self.assertEqual(instance.validated, 1)
+        self.assertEqual(instance._name, "configured")
+
+    def testRestartUpdatePolicy(self) -> None:
+        """
+        With the "restart" policy, @RequiresConfiguration must invalidate the
+        component before applying the new properties
+        """
+        instance = self.get_instance("configadmin-restart")
+        self.assertEqual((instance.validated, instance.invalidated), (0, 0))
+
+        config = self.config.get_configuration(PID_RESTART)
+        config.update({"name": "configured"})
+        self.pause()
+        self.assertEqual((instance.validated, instance.invalidated), (1, 0))
+        self.assertEqual(instance._name, "configured")
+
+        # An update invalidates then validates the component again
+        config.update({"name": "updated"})
+        self.pause()
+        self.assertEqual((instance.validated, instance.invalidated), (2, 1))
+        self.assertEqual(instance._name, "updated")
+
+        config.delete()
+        self.pause()
+        self.assertEqual((instance.validated, instance.invalidated), (2, 2))
+        self.assertEqual(instance._name, "default")
+
+    def testMissingPid(self) -> None:
+        """
+        A component using @RequiresConfiguration without any PID can't be
+        validated
+        """
+        from pelix.ipopo.instance import StoredInstance
+
+        instance = self.get_instance("configadmin-no-pid")
+        self.assertEqual(instance.validated, 0)
+        self.assertEqual(self.get_state("configadmin-no-pid"), StoredInstance.INVALID)
+
+    def testHiddenPropertyIsKept(self) -> None:
+        """
+        A configuration entry named after a hidden property must be ignored
+        """
+        instance = self.get_instance("configadmin-hidden")
+        self.assertEqual(instance._secret, "declared-secret")
+
+        config = self.config.get_configuration(PID_HIDDEN)
+        config.update({"name": "configured", "secret": "from-configuration"})
+        self.pause()
+
+        # The visible property has been updated, the hidden one hasn't
+        self.assertEqual(instance._name, "configured")
+        self.assertEqual(instance._secret, "declared-secret")
+
+        # ... and the value of the configuration hasn't become public
+        with use_ipopo(self.context) as ipopo:
+            properties = ipopo.get_instance_details("configadmin-hidden")["properties"]
+
+        self.assertNotIn("secret", properties)
+
+    def testHiddenPropertyWarnsOnce(self) -> None:
+        """
+        The whole configuration is sent again on each update: the refusal to
+        update a hidden property must not be logged every time
+        """
+        config = self.config.get_configuration(PID_HIDDEN)
+
+        with self.assertLogs("InstanceManager-configadmin-hidden", "WARNING") as logs:
+            config.update({"name": "first", "secret": "from-configuration"})
+            self.pause()
+            config.update({"name": "second", "secret": "from-configuration"})
+            self.pause()
+
+        self.assertEqual(len(logs.records), 1, "Hidden property warning logged more than once")
+
+    def testHiddenPropertyDotOverride(self) -> None:
+        """
+        A configuration entry named after a hidden property, prefixed with a
+        dot, must update it confidentially
+        """
+        instance = self.get_instance("configadmin-hidden")
+        self.assertEqual(instance._secret, "declared-secret")
+
+        config = self.config.get_configuration(PID_HIDDEN)
+        config.update({"name": "configured", ".secret": "rotated-secret"})
+        self.pause()
+
+        self.assertEqual(instance._name, "configured")
+        self.assertEqual(instance._secret, "rotated-secret")
+
+        # ... and the value still hasn't become public
+        with use_ipopo(self.context) as ipopo:
+            properties = ipopo.get_instance_details("configadmin-hidden")["properties"]
+
+        self.assertNotIn("secret", properties)
+        self.assertNotIn(".secret", properties)
+
+    def testHiddenPropertyDotOverrideRestoresDefault(self) -> None:
+        """
+        Removing the dot-prefixed override from the configuration must
+        restore the hidden property's declared default, not None
+        """
+        instance = self.get_instance("configadmin-hidden")
+
+        config = self.config.get_configuration(PID_HIDDEN)
+        config.update({"name": "configured", ".secret": "rotated-secret"})
+        self.pause()
+        self.assertEqual(instance._secret, "rotated-secret")
+
+        config.update({"name": "configured"})
+        self.pause()
+        self.assertEqual(instance._secret, "declared-secret")
+
+    def testPidSurvivesConfigurationDeletion(self) -> None:
+        """
+        Deleting a configuration must not take away the PID of the component:
+        the factory doesn't declare that value, so it can't be restored
+        """
+        instance = self.get_instance("configadmin-undeclared-pid")
+        ldap_filter = f"({SERVICE_PID}={PID_UNDECLARED})"
+        self.assertIsNotNone(self.context.get_service_reference(SPEC_UNDECLARED_PID, ldap_filter))
+
+        config = self.config.get_configuration(PID_UNDECLARED)
+        config.update({"name": "configured"})
+        self.pause()
+        self.assertEqual(instance._name, "configured")
+
+        config.delete()
+        self.pause()
+
+        # The property given by the configuration is back to its declared value
+        self.assertEqual(instance._name, "default")
+
+        # ... but the component is still reachable by its PID
+        self.assertIsNotNone(self.context.get_service_reference(SPEC_UNDECLARED_PID, ldap_filter))
+
+    def testConfigAdminEntriesAreNotProperties(self) -> None:
+        """
+        The entries describing the configuration itself must never become
+        properties of the component
+        """
+
+        def properties() -> dict[str, Any]:
+            with use_ipopo(self.context) as ipopo:
+                return ipopo.get_instance_details("configadmin-gated")["properties"]
+
+        config = self.config.get_configuration(PID_GATED)
+        config.update({"name": "configured"})
+        self.pause()
+        self.assertNotIn(services.CONFIG_PROP_PID, properties())
+        self.assertNotIn(services.CONFIG_PROP_FACTORY_PID, properties())
+
+        config.delete()
+        self.pause()
+        self.assertNotIn(services.CONFIG_PROP_PID, properties())
+        self.assertNotIn(services.CONFIG_PROP_FACTORY_PID, properties())
+
+    def testUnsetPidIsNotTracked(self) -> None:
+        """
+        A component which declares a service.pid property without giving it a
+        value must not be associated to any configuration
+        """
+        instance = self.get_instance("configadmin-unset-pid")
+        self.assertEqual(instance._name, "default")
+
+        # No managed service must have been registered for that component
+        managed_pids = {
+            ref.get_property(SERVICE_PID)
+            for ref in self.context.get_all_service_references(services.IManagedService) or []
+        }
+        self.assertNotIn(str(None), managed_pids)
+        self.assertNotIn(None, managed_pids)
+
+        # A configuration named after the string representation of None must
+        # not reach the component
+        config = self.config.get_configuration(str(None))
+        config.update({"name": "hijacked"})
+        self.pause()
+
+        self.assertEqual(instance._name, "default")
+
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    # Set logging level
+    import logging
+
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/tests/ipopo/test_hidden_props.py
+++ b/tests/ipopo/test_hidden_props.py
@@ -95,6 +95,37 @@ class HiddenPropTest(unittest.TestCase):
 
         self.assertNotIn("hidden.prop", details["properties"])
 
+    def test_hidden_reconfigure_dot_override(self):
+        """
+        Tests that a hidden property can be updated confidentially through
+        reconfigure() by prefixing its name with a dot, while its plain name
+        is still ignored
+        """
+        context = self.framework.get_bundle_context()
+
+        with use_ipopo(context) as ipopo:
+            svc = ipopo.instantiate(self.module.FACTORY_HIDDEN_PROPS, NAME_A)
+
+        self.assertEqual(svc.hidden, "hidden")
+
+        # A plain name is ignored
+        with use_ipopo(context) as ipopo:
+            ipopo.reconfigure(NAME_A, {"hidden.prop": "ignored"})
+
+        self.assertEqual(svc.hidden, "hidden")
+
+        # A dot-prefixed name updates the hidden property
+        with use_ipopo(context) as ipopo:
+            ipopo.reconfigure(NAME_A, {".hidden.prop": "rotated"})
+
+        self.assertEqual(svc.hidden, "rotated")
+
+        # ... and still doesn't become public
+        with use_ipopo(context) as ipopo:
+            details = ipopo.get_instance_details(NAME_A)
+
+        self.assertNotIn("hidden.prop", details["properties"])
+
 
 # ------------------------------------------------------------------------------
 

--- a/tests/ipopo/test_waiting_list.py
+++ b/tests/ipopo/test_waiting_list.py
@@ -188,6 +188,132 @@ class WaitingListTest(unittest.TestCase):
         # The original instance must still be there
         self.assertTrue(ipopo.is_registered_instance(module.BASIC_INSTANCE), "Instance has been killed")
 
+    def testUpdateQueuedComponent(self):
+        """
+        An update of a queued component must be merged into its properties,
+        as it is for a running one
+        """
+        assert self.framework is not None
+        assert self.waiting is not None
+
+        # Add the component to the waiting list, before iPOPO is there
+        self.waiting.add(FACTORY_A, NAME_A, {"kept": 1, "changed": 2})
+
+        # Only mention one of the properties
+        self.waiting.update(NAME_A, {"changed": 3, "added": 4})
+
+        # Install iPOPO and the component bundle
+        ipopo = install_ipopo(self.framework)
+        install_bundle(self.framework)
+
+        self.assertTrue(ipopo.is_registered_instance(NAME_A), "Instance not there")
+
+        properties = ipopo.get_instance_details(NAME_A)["properties"]
+        self.assertEqual(properties["kept"], "1", "Untouched property has been lost")
+        self.assertEqual(properties["changed"], "3", "Property has not been updated")
+        self.assertEqual(properties["added"], "4", "Property has not been added")
+
+    def testUpdateRemovedProperties(self):
+        """
+        The properties named in "removed" must be dropped from the queue, so
+        that the factory gives them their declared value again
+        """
+        assert self.framework is not None
+        assert self.waiting is not None
+
+        # Add the component to the waiting list, before iPOPO is there
+        self.waiting.add(FACTORY_A, NAME_A, {"kept": 1, "dropped": 2})
+
+        # Drop a property, giving it the value the factory would give it
+        self.waiting.update(NAME_A, {"dropped": None}, {"dropped"})
+
+        # Install iPOPO and the component bundle
+        ipopo = install_ipopo(self.framework)
+        install_bundle(self.framework)
+
+        self.assertTrue(ipopo.is_registered_instance(NAME_A), "Instance not there")
+
+        properties = ipopo.get_instance_properties(NAME_A)
+        self.assertEqual(properties["kept"], 1, "Untouched property has been lost")
+        self.assertNotIn("dropped", properties, "Property has not been dropped")
+
+    def testUpdateUnknownComponent(self):
+        """
+        Updating a component which is not in the waiting list must raise a
+        KeyError
+        """
+        assert self.waiting is not None
+        self.assertRaises(KeyError, self.waiting.update, NAME_A, {"name": "value"})
+
+    def testUpdateDuringInstantiation(self):
+        """
+        An update which happens while the component is being instantiated must
+        not be lost: its reconfiguration is ignored, as the component is not
+        registered yet
+        """
+        assert self.framework is not None
+        assert self.waiting is not None
+
+        # Install iPOPO and the component bundle
+        ipopo = install_ipopo(self.framework)
+        install_bundle(self.framework)
+
+        waiting = self.waiting
+        original_instantiate = ipopo.instantiate
+
+        def racing_instantiate(factory, name, properties=None):
+            """
+            Updates the queued properties before the component is registered
+            """
+            # Race only once
+            ipopo.instantiate = original_instantiate
+            waiting.update(NAME_A, {"changed": 3})
+            return original_instantiate(factory, name, properties)
+
+        ipopo.instantiate = racing_instantiate
+
+        self.waiting.add(FACTORY_A, NAME_A, {"kept": 1, "changed": 2})
+        self.assertTrue(ipopo.is_registered_instance(NAME_A), "Instance not there")
+
+        properties = ipopo.get_instance_properties(NAME_A)
+        self.assertEqual(properties["kept"], 1, "Untouched property has been lost")
+        self.assertEqual(properties["changed"], 3, "Concurrent update has been lost")
+
+    def testAddDuringRemoval(self):
+        """
+        A component queued again while the previous one is being killed must
+        stay instantiated
+        """
+        assert self.framework is not None
+        assert self.waiting is not None
+
+        # Install iPOPO and the component bundle
+        ipopo = install_ipopo(self.framework)
+        install_bundle(self.framework)
+
+        self.waiting.add(FACTORY_A, NAME_A, {})
+        self.assertTrue(ipopo.is_registered_instance(NAME_A), "Instance not there")
+
+        waiting = self.waiting
+        original_kill = ipopo.kill
+
+        def racing_kill(name):
+            """
+            Queues the component again before it is killed
+            """
+            # Race only once
+            ipopo.kill = original_kill
+
+            # The component is still running: this add() only queues it back,
+            # which is what the removal must take into account
+            waiting.add(FACTORY_A, NAME_A, {})
+            return original_kill(name)
+
+        ipopo.kill = racing_kill
+
+        self.waiting.remove(NAME_A)
+        self.assertTrue(ipopo.is_registered_instance(NAME_A), "Queued component has been killed")
+
 
 # ------------------------------------------------------------------------------
 

--- a/tests/services/configadmin_factory_bundle.py
+++ b/tests/services/configadmin_factory_bundle.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Bundle defining a managed service factory to be updated by ConfigAdmin
+
+:author: Thomas Calmant
+"""
+
+from typing import Any
+
+from pelix import constants, services
+from pelix.ipopo.decorators import ComponentFactory, Instantiate, Property, Provides
+
+# ------------------------------------------------------------------------------
+
+FACTORY_PID = "test.ca.factory"
+
+# ------------------------------------------------------------------------------
+
+
+@ComponentFactory()
+@Provides(services.IManagedServiceFactory)
+@Property("_factory_pid", constants.SERVICE_PID, FACTORY_PID)
+@Instantiate("configadmin-factory-test")
+class ConfigurableFactory(services.IManagedServiceFactory):
+    """
+    Configurable managed service factory
+    """
+
+    _factory_pid: str
+
+    def __init__(self) -> None:
+        """
+        Sets up members
+        """
+        # PID -> configuration properties
+        self.configurations: dict[str, dict[str, Any]] = {}
+        self.deleted_pids: list[str] = []
+        self.call_count = 0
+
+    def reset(self) -> None:
+        """
+        Resets the flags
+        """
+        self.configurations.clear()
+        del self.deleted_pids[:]
+        self.call_count = 0
+
+    def get_name(self) -> str:
+        """
+        Returns the name of the factory
+        """
+        return FACTORY_PID
+
+    def updated(self, pid: str, properties: dict[str, Any] | None) -> None:
+        """
+        Called by the ConfigurationAdmin service
+        """
+        self.call_count += 1
+        self.configurations[pid] = properties or {}
+
+    def deleted(self, pid: str) -> None:
+        """
+        Called by the ConfigurationAdmin service
+        """
+        self.call_count += 1
+        self.deleted_pids.append(pid)
+        self.configurations.pop(pid, None)

--- a/tests/services/test_configadmin.py
+++ b/tests/services/test_configadmin.py
@@ -10,18 +10,25 @@ import json
 import os
 import shutil
 import tempfile
+import threading
 import time
 import unittest
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, cast
 
 import pelix.framework
-from pelix import services
+from pelix import constants, services
 from pelix.internals.registry import ServiceReference
-from pelix.services.configadmin import JsonPersistence
+from pelix.services.configadmin import (
+    ConfigurationDirectory,
+    IConfigurationAdminDirectory,
+    JsonPersistence,
+)
 from pelix.utilities import use_service
 
 if TYPE_CHECKING:
     from .configadmin_bundle import Configurable
+    from .configadmin_factory_bundle import ConfigurableFactory
 
 # ------------------------------------------------------------------------------
 
@@ -364,6 +371,22 @@ class ManagedServiceTest(unittest.TestCase):
             self.assertIsNone(svc.value, "Value has been set")
             self.assertFalse(svc.deleted, "Configuration considered as deleted")
 
+    def testNoPhantomConfiguration(self) -> None:
+        """
+        Registering a managed service for a PID which has no configuration
+        must not create one
+        """
+        self.assertFalse(list(self.config.list_configurations()))
+
+        # Start the test bundle: it registers a managed service
+        self.bundle.start()
+        self.pause()
+
+        self.assertFalse(
+            [config.get_pid() for config in self.config.list_configurations()],
+            "A configuration has been created out of thin air",
+        )
+
     def testEarlyConfig(self) -> None:
         """
         Tests the behaviour if a configuration is already set when the managed
@@ -477,6 +500,665 @@ class ManagedServiceTest(unittest.TestCase):
             # The flag must have been set
             self.check_call_count(svc, 1)
             self.assertTrue(svc.deleted, "Configuration considered as deleted")
+
+
+# ------------------------------------------------------------------------------
+
+
+class ManagedServiceFactoryTest(unittest.TestCase):
+    """
+    Tests the behavior of managed service factories
+    """
+
+    framework: pelix.framework.Framework
+    config_ref: ServiceReference[services.IConfigurationAdmin] | None
+    config: services.IConfigurationAdmin
+
+    def setUp(self) -> None:
+        """
+        Sets up the test
+        """
+        self.framework = pelix.framework.create_framework(
+            ("pelix.ipopo.core", "pelix.services.configadmin"), {"configuration.folder": conf_folder}
+        )
+        self.addCleanup(self.framework.delete, True)
+        self.framework.start()
+        context = self.framework.get_bundle_context()
+
+        # Get the ConfigAdmin service
+        self.config_ref = context.get_service_reference(services.IConfigurationAdmin)
+        assert self.config_ref is not None
+        self.config = context.get_service(self.config_ref)
+
+        # Install the test bundle (don't start it)
+        self.bundle = context.install_bundle("tests.services.configadmin_factory_bundle")
+        self.factory_pid = self.bundle.get_module().FACTORY_PID
+
+        # Remove existing configurations
+        for config in self.config.list_configurations():
+            config.delete()
+
+    def tearDown(self) -> None:
+        """
+        Cleans up for next test
+        """
+        # Remove existing configurations
+        for config in self.config.list_configurations():
+            config.delete()
+
+        # Release the service
+        if self.config_ref is not None:
+            self.framework.get_bundle_context().unget_service(self.config_ref)
+            self.config_ref = None
+
+        pelix.framework.FrameworkFactory.delete_framework()
+        self.config = None  # type: ignore
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Cleans up after all tests have been executed
+        """
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+    def get_ref(self) -> ServiceReference[services.IManagedServiceFactory]:
+        """
+        Retrieves the reference to the managed service factory provided by the
+        test bundle
+        """
+        return self.bundle.get_registered_services()[0]
+
+    def pause(self) -> None:
+        """
+        Small pause to let the task pool notify the services
+        """
+        time.sleep(0.2)
+
+    def testFactoryConfigurations(self) -> None:
+        """
+        The factory must be notified of the configurations created before and
+        after its registration
+        """
+        # Configuration created before the factory is registered
+        early = self.config.create_factory_configuration(self.factory_pid)
+        early.update({"config.value": 21})
+
+        self.bundle.start()
+        self.pause()
+
+        with use_service(self.framework.get_bundle_context(), self.get_ref()) as svc:
+            svc = cast("ConfigurableFactory", svc)
+
+            self.assertEqual(list(svc.configurations), [early.get_pid()])
+            self.assertEqual(svc.configurations[early.get_pid()]["config.value"], 21)
+
+            # The automatic properties must be there
+            self.assertEqual(
+                svc.configurations[early.get_pid()][services.CONFIG_PROP_FACTORY_PID],
+                self.factory_pid,
+            )
+            self.assertEqual(svc.configurations[early.get_pid()][services.CONFIG_PROP_PID], early.get_pid())
+
+            # Configuration created after the factory is registered
+            late = self.config.create_factory_configuration(self.factory_pid)
+            late.update({"config.value": 42})
+            self.pause()
+
+            self.assertEqual(len(svc.configurations), 2)
+            self.assertEqual(svc.configurations[late.get_pid()]["config.value"], 42)
+
+            # Update of an existing configuration
+            svc.reset()
+            late.update({"config.value": 43})
+            self.pause()
+
+            self.assertEqual(svc.call_count, 1)
+            self.assertEqual(svc.configurations[late.get_pid()]["config.value"], 43)
+
+            # Deletion
+            svc.reset()
+            late_pid = late.get_pid()
+            late.delete()
+            self.pause()
+
+            self.assertEqual(svc.deleted_pids, [late_pid])
+            self.assertNotIn(late_pid, svc.configurations)
+
+    def testNoUpdateBeforeProperties(self) -> None:
+        """
+        A configuration which has never been updated must not be notified
+        """
+        self.config.create_factory_configuration(self.factory_pid)
+
+        self.bundle.start()
+        self.pause()
+
+        with use_service(self.framework.get_bundle_context(), self.get_ref()) as svc:
+            svc = cast("ConfigurableFactory", svc)
+            self.assertEqual(svc.configurations, {})
+            self.assertEqual(svc.call_count, 0)
+
+
+# ------------------------------------------------------------------------------
+
+
+class _ReentrantService(services.IManagedService):
+    """
+    Managed service which calls back into ConfigurationAdmin from its
+    notification
+    """
+
+    def __init__(self, config_admin: services.IConfigurationAdmin) -> None:
+        """
+        :param config_admin: The ConfigurationAdmin service
+        """
+        self.__config_admin = config_admin
+        self.__thread: threading.Thread | None = None
+
+        self.call_count = 0
+
+        # True if the last notification let another thread use the directory
+        self.directory_free = False
+
+    def __create_configuration(self) -> None:
+        """
+        Makes a call which needs the configurations directory
+        """
+        self.__config_admin.create_factory_configuration("test.reentrant.factory")
+
+    def updated(self, properties: dict[str, Any] | None) -> None:
+        """
+        Called by the ConfigurationAdmin service
+        """
+        self.call_count += 1
+
+        # Call back into ConfigurationAdmin from another thread: a direct call
+        # would deadlock if the directory is locked, whereas this one is only
+        # delayed until this notification returns
+        self.__thread = threading.Thread(target=self.__create_configuration, daemon=True)
+        self.__thread.start()
+        self.__thread.join(5)
+        self.directory_free = not self.__thread.is_alive()
+
+    def reset(self) -> bool:
+        """
+        Waits for the end of the call back of the last notification and resets
+        the flags
+
+        :return: True if the call back is over
+        """
+        thread, self.__thread = self.__thread, None
+        if thread is not None:
+            thread.join(10)
+            if thread.is_alive():
+                return False
+
+        self.call_count = 0
+        self.directory_free = False
+        return True
+
+
+class ConfigurationDirectoryTest(unittest.TestCase):
+    """
+    Tests the locking of the configurations directory
+    """
+
+    PID = "test.reentrant"
+
+    def setUp(self) -> None:
+        """
+        Sets up the test
+        """
+        self.framework = pelix.framework.create_framework(
+            ("pelix.ipopo.core", "pelix.services.configadmin"), {"configuration.folder": conf_folder}
+        )
+        self.addCleanup(self.framework.delete, True)
+        self.framework.start()
+        self.context = self.framework.get_bundle_context()
+
+        config_ref = self.context.get_service_reference(services.IConfigurationAdmin)
+        assert config_ref is not None
+        self.config = self.context.get_service(config_ref)
+
+        directory_ref = self.context.get_service_reference(IConfigurationAdminDirectory)
+        assert directory_ref is not None
+        self.directory = self.context.get_service(directory_ref)
+
+        # Register the service before the configuration is valid: it is not
+        # notified yet
+        self.service = _ReentrantService(self.config)
+        configuration = self.config.get_configuration(self.PID)
+        self.context.register_service(
+            services.IManagedService, self.service, {constants.SERVICE_PID: self.PID}
+        )
+
+        # Make the configuration valid. Nothing holds the directory lock here,
+        # so this first notification always goes through
+        configuration.update({"answer": 0})
+        self.assertTrue(self.service.reset(), "Notification of the first update didn't return")
+
+    def tearDown(self) -> None:
+        """
+        Cleans up for next test
+        """
+        self.service.reset()
+        pelix.framework.FrameworkFactory.delete_framework()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Cleans up after all tests have been executed
+        """
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+    def testUpdateNotifiesOutsideOfTheLock(self) -> None:
+        """
+        A managed service notified of an update must be able to call back into
+        ConfigurationAdmin
+        """
+        self.directory.update(self.PID, {"answer": 42})
+
+        self.assertEqual(self.service.call_count, 1)
+        self.assertTrue(self.service.directory_free, "Directory locked while notifying an update")
+
+    def testDeleteNotifiesOutsideOfTheLock(self) -> None:
+        """
+        A managed service notified of a deletion must be able to call back into
+        ConfigurationAdmin
+        """
+        self.directory.delete(self.PID)
+
+        self.assertEqual(self.service.call_count, 1)
+        self.assertTrue(self.service.directory_free, "Directory locked while notifying a deletion")
+
+
+# ------------------------------------------------------------------------------
+
+
+class _WatchingService(services.IManagedService):
+    """
+    Managed service which looks at ConfigurationAdmin while it is notified of
+    the deletion of its configuration
+    """
+
+    def __init__(
+        self,
+        config_admin: services.IConfigurationAdmin,
+        directory: IConfigurationAdminDirectory,
+        pid: str,
+    ) -> None:
+        """
+        :param config_admin: The ConfigurationAdmin service
+        :param directory: The configurations directory
+        :param pid: PID of the followed configuration
+        """
+        self.__config_admin = config_admin
+        self.__directory = directory
+        self.__pid = pid
+
+        # Number of notified deletions
+        self.deletions = 0
+
+        # What ConfigurationAdmin showed during the deletion
+        self.listed_pids: set[str] = set()
+        self.directory_lookup: services.Configuration | None = None
+        self.replacement: services.Configuration | None = None
+
+    def updated(self, properties: dict[str, Any] | None) -> None:
+        """
+        Called by the ConfigurationAdmin service
+        """
+        if properties is not None:
+            return
+
+        self.deletions += 1
+        self.listed_pids = {config.get_pid() for config in self.__config_admin.list_configurations()}
+
+        try:
+            self.directory_lookup = self.__directory.get_configuration(self.__pid)
+        except KeyError:
+            self.directory_lookup = None
+
+        # A new configuration must be usable for this PID right away
+        self.replacement = self.__config_admin.get_configuration(self.__pid)
+
+
+class DeletedConfigurationTest(unittest.TestCase):
+    """
+    Tests the visibility of a configuration which is being deleted
+    """
+
+    PID = "test.deleted"
+
+    def setUp(self) -> None:
+        """
+        Sets up the test
+        """
+        self.framework = pelix.framework.create_framework(
+            ("pelix.ipopo.core", "pelix.services.configadmin"), {"configuration.folder": conf_folder}
+        )
+        self.addCleanup(self.framework.delete, True)
+        self.framework.start()
+        self.context = self.framework.get_bundle_context()
+
+        config_ref = self.context.get_service_reference(services.IConfigurationAdmin)
+        assert config_ref is not None
+        self.config = self.context.get_service(config_ref)
+
+        directory_ref = self.context.get_service_reference(IConfigurationAdminDirectory)
+        assert directory_ref is not None
+        self.directory = self.context.get_service(directory_ref)
+
+        self.service = _WatchingService(self.config, self.directory, self.PID)
+        self.context.register_service(
+            services.IManagedService, self.service, {constants.SERVICE_PID: self.PID}
+        )
+
+        # Make the configuration valid, so that its deletion is notified
+        self.config.get_configuration(self.PID).update({"answer": 42})
+
+    def tearDown(self) -> None:
+        """
+        Cleans up for next test
+        """
+        pelix.framework.FrameworkFactory.delete_framework()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Cleans up after all tests have been executed
+        """
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+    def testDeletedConfigurationIsHidden(self) -> None:
+        """
+        A configuration which is being deleted must not be given back by
+        ConfigurationAdmin, and its PID must be usable again right away
+        """
+        self.directory.delete(self.PID)
+        self.assertEqual(self.service.deletions, 1)
+
+        # The dying configuration was already gone for its users
+        self.assertNotIn(self.PID, self.service.listed_pids)
+        self.assertIsNone(self.service.directory_lookup)
+
+        # The configuration created in the meantime must have survived the end
+        # of the deletion
+        replacement = self.service.replacement
+        assert replacement is not None
+        self.assertIsNone(replacement.get_properties())
+        self.assertIs(self.directory.get_configuration(self.PID), replacement)
+
+
+class _MemoryPersistence(services.IConfigurationAdminPersistence):
+    """
+    Persistence service which keeps the configurations in memory
+    """
+
+    def __init__(self) -> None:
+        """
+        Sets up members
+        """
+        self.storage: dict[str, dict[str, Any]] = {}
+
+    def get_pids(self) -> Iterable[str]:
+        """
+        Returns the PIDs of the stored configurations
+        """
+        return list(self.storage)
+
+    def exists(self, pid: str) -> bool:
+        """
+        Checks if a configuration is stored
+        """
+        return pid in self.storage
+
+    def load(self, pid: str) -> dict[str, Any]:
+        """
+        Loads a stored configuration
+        """
+        return self.storage[pid].copy()
+
+    def store(self, pid: str, properties: dict[str, Any]) -> None:
+        """
+        Stores a configuration
+        """
+        self.storage[pid] = properties.copy()
+
+    def delete(self, pid: str) -> bool:
+        """
+        Forgets a stored configuration
+        """
+        return self.storage.pop(pid, None) is not None
+
+
+class _FailingPersistence(_MemoryPersistence):
+    """
+    Persistence service which refuses to delete its configurations
+    """
+
+    def delete(self, pid: str) -> bool:
+        """
+        Always fails to delete the configuration
+        """
+        raise OSError(f"Can't delete {pid}")
+
+
+class _LookupPersistence(_MemoryPersistence):
+    """
+    Persistence service which looks for the configuration it is deleting: at
+    that point, the configuration is still stored
+    """
+
+    def __init__(self) -> None:
+        """
+        Sets up members
+        """
+        super().__init__()
+
+        # The ConfigurationAdmin service, given by the test
+        self.config_admin: services.IConfigurationAdmin | None = None
+
+        # What ConfigurationAdmin gave back during the deletion
+        self.lookup: services.Configuration | None = None
+
+    def delete(self, pid: str) -> bool:
+        """
+        Looks for the configuration, then forgets it
+        """
+        if self.config_admin is not None and self.lookup is None:
+            # Look only once: the lookup itself can start a deletion
+            self.lookup = self.config_admin.get_configuration(pid)
+
+        return super().delete(pid)
+
+
+class _DeletionCounter(services.IManagedService):
+    """
+    Managed service which counts the deletions of its configuration
+    """
+
+    def __init__(self) -> None:
+        """
+        Sets up members
+        """
+        self.deletions = 0
+
+    def updated(self, properties: dict[str, Any] | None) -> None:
+        """
+        Called by the ConfigurationAdmin service
+        """
+        if properties is None:
+            self.deletions += 1
+
+
+class PersistenceErrorTest(unittest.TestCase):
+    """
+    Tests the deletion of a configuration when the persistence service fails
+    """
+
+    PID = "test.persistence.error"
+
+    def setUp(self) -> None:
+        """
+        Sets up the test
+        """
+        self.framework = pelix.framework.create_framework(
+            ("pelix.ipopo.core",), {"configuration.folder": conf_folder}
+        )
+        self.addCleanup(self.framework.delete, True)
+        self.framework.start()
+        self.context = self.framework.get_bundle_context()
+
+        # Register the services before ConfigurationAdmin is started: the best
+        # ranked persistence is the one used for the new configurations
+        self.persistence = _FailingPersistence()
+        self.context.register_service(
+            services.IConfigurationAdminPersistence,
+            self.persistence,
+            {constants.SERVICE_RANKING: 1000},
+        )
+
+        self.service = _DeletionCounter()
+        self.context.register_service(
+            services.IManagedService, self.service, {constants.SERVICE_PID: self.PID}
+        )
+
+        self.context.install_bundle("pelix.services.configadmin").start()
+
+        config_ref = self.context.get_service_reference(services.IConfigurationAdmin)
+        assert config_ref is not None
+        self.config = self.context.get_service(config_ref)
+
+        directory_ref = self.context.get_service_reference(IConfigurationAdminDirectory)
+        assert directory_ref is not None
+        self.directory = self.context.get_service(directory_ref)
+
+    def tearDown(self) -> None:
+        """
+        Cleans up for next test
+        """
+        pelix.framework.FrameworkFactory.delete_framework()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Cleans up after all tests have been executed
+        """
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+    def testDeletionErrorStillNotifies(self) -> None:
+        """
+        A persistence error must be given back to the caller, but must not stop
+        the deletion of the configuration
+        """
+        configuration = self.config.get_configuration(self.PID)
+        configuration.update({"answer": 42})
+        self.assertIn(self.PID, self.persistence.storage, "The test persistence wasn't used")
+
+        self.assertRaises(OSError, configuration.delete)
+
+        # The managed service has been notified and the configuration is gone
+        self.assertEqual(self.service.deletions, 1)
+        self.assertFalse(configuration.is_valid())
+        self.assertRaises(KeyError, self.directory.get_configuration, self.PID)
+
+    def testDirectoryDeletionErrorCleansUp(self) -> None:
+        """
+        A persistence error must not stop the directory from forgetting the
+        configuration it deletes
+        """
+        factory_pid = f"{self.PID}.factory"
+        configuration = self.config.create_factory_configuration(factory_pid)
+        configuration.update({"answer": 42})
+
+        pid = configuration.get_pid()
+        self.assertIn(pid, self.persistence.storage, "The test persistence wasn't used")
+
+        self.assertRaises(OSError, self.directory.delete, pid)
+
+        # The configuration is gone, even though it is still stored
+        directory = cast(ConfigurationDirectory, self.directory)
+        self.assertFalse(directory.exists(pid), "Configuration still in the directory")
+        self.assertRaises(KeyError, self.directory.get_configuration, pid)
+        self.assertEqual(
+            self.directory.get_factory_configurations(factory_pid),
+            set(),
+            "Configuration still associated to its factory",
+        )
+
+
+# ------------------------------------------------------------------------------
+
+
+class DeletionLookupTest(unittest.TestCase):
+    """
+    Tests the lookup of a configuration while it is being deleted
+    """
+
+    PID = "test.deletion.lookup"
+
+    def setUp(self) -> None:
+        """
+        Sets up the test
+        """
+        self.framework = pelix.framework.create_framework(
+            ("pelix.ipopo.core",), {"configuration.folder": conf_folder}
+        )
+        self.addCleanup(self.framework.delete, True)
+        self.framework.start()
+        self.context = self.framework.get_bundle_context()
+
+        # Register the persistence before ConfigurationAdmin is started: the
+        # best ranked one is used for the new configurations
+        self.persistence = _LookupPersistence()
+        self.context.register_service(
+            services.IConfigurationAdminPersistence,
+            self.persistence,
+            {constants.SERVICE_RANKING: 1000},
+        )
+
+        self.context.install_bundle("pelix.services.configadmin").start()
+
+        config_ref = self.context.get_service_reference(services.IConfigurationAdmin)
+        assert config_ref is not None
+        self.config = self.context.get_service(config_ref)
+        self.persistence.config_admin = self.config
+
+        directory_ref = self.context.get_service_reference(IConfigurationAdminDirectory)
+        assert directory_ref is not None
+        self.directory = self.context.get_service(directory_ref)
+
+    def tearDown(self) -> None:
+        """
+        Cleans up for next test
+        """
+        pelix.framework.FrameworkFactory.delete_framework()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Cleans up after all tests have been executed
+        """
+        shutil.rmtree(conf_folder, ignore_errors=True)
+
+    def testLookupDuringDeletion(self) -> None:
+        """
+        A lookup made while the configuration is being removed from the
+        persistence must give back that configuration, not a copy loaded from
+        its stored properties
+        """
+        configuration = self.config.get_configuration(self.PID)
+        configuration.update({"answer": 42})
+        self.assertIn(self.PID, self.persistence.storage, "The test persistence wasn't used")
+
+        configuration.delete()
+
+        self.assertIs(self.persistence.lookup, configuration, "A duplicate configuration was created")
+
+        # The deletion went through
+        self.assertNotIn(self.PID, self.persistence.storage, "Configuration still stored")
+        self.assertRaises(KeyError, self.directory.get_configuration, self.PID)
 
 
 # ------------------------------------------------------------------------------
@@ -667,6 +1349,54 @@ class FileInstallTest(unittest.TestCase):
             svc = cast("Configurable", svc)
             self.check_call_count(svc, 1)
             self.assertTrue(svc.deleted, "Configuration not deleted")
+
+    def testAddFactoryConfiguration(self) -> None:
+        """
+        A configuration file added in the watched folder must reach the managed
+        service factories, not only the managed services
+        """
+        context = self.framework.get_bundle_context()
+
+        # Install and start the managed service factory
+        factory_bundle = context.install_bundle("tests.services.configadmin_factory_bundle")
+        factory_bundle.start()
+        factory_pid = factory_bundle.get_module().FACTORY_PID
+        factory_ref = factory_bundle.get_registered_services()[0]
+
+        # Start file install
+        self.start_fileinstall()
+
+        # Get the watched folder
+        persistence_ref = context.get_service_reference(services.IConfigurationAdminPersistence)
+        assert persistence_ref is not None
+        folder = persistence_ref.get_property(services.PROP_FILEINSTALL_FOLDER)
+
+        # Write a factory configuration file
+        pid = f"{factory_pid}-fileinstall"
+        filepath = os.path.join(folder, pid + ".config.js")
+        self.addCleanup(os.remove, filepath)
+
+        with open(filepath, "w") as filep:
+            json.dump(
+                {
+                    services.CONFIG_PROP_PID: pid,
+                    services.CONFIG_PROP_FACTORY_PID: factory_pid,
+                    "config.value": 42,
+                },
+                filep,
+            )
+
+        # Wait for the folder to be polled
+        for _ in range(30):
+            time.sleep(0.2)
+            with use_service(context, factory_ref) as svc:
+                if cast("ConfigurableFactory", svc).configurations:
+                    break
+
+        with use_service(context, factory_ref) as svc:
+            svc = cast("ConfigurableFactory", svc)
+            self.assertIn(pid, svc.configurations, "Managed service factory not notified")
+            self.assertEqual(svc.configurations[pid]["config.value"], 42)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
- Allows to instantiate/update components via configurations
- Allows components to wait for a configuration before being validated
- Fixes issues with configuration admin