### PR TITLE
First implementation of pelix.security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ _build/
 # Jupyter Notebooks
 .ipynb_checkpoints/
 *.ipynb
+
+# Temporary folders
+/tmp
+/temp
+/work

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -48,6 +48,23 @@ Unreleased
 * Added tests for the configuration of ConfigurationAdmin managed service
   factories
 
+### HTTP service
+
+* Request paths are now normalized (decoded, collapsed, resolved) before
+  routing, and `get_path()` / `get_sub_path()` return that normalized path
+* A malformed or out-of-root path now gets a 400 error instead of reaching a
+  servlet
+* The Remote Services dispatcher servlet now routes on its relative path
+  instead of counting segments
+
+### Security
+
+All versions up to 3.2.2 are affected.
+
+* Servlet paths are now matched case-sensitively (breaking change: see
+  `pelix.http.case_sensitive_paths` to opt out)
+* Servlet paths are no longer vulnerable to path traversal
+
 ## iPOPO 3.2.2
 
 :::{admonition} Release Date

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -56,6 +56,13 @@ Unreleased
   servlet
 * The Remote Services dispatcher servlet now routes on its relative path
   instead of counting segments
+* The asynchronous HTTP service now carries the caller's context variables
+  into the servlet it dispatches to
+
+### Utilities
+
+* `ThreadPool` now runs each task in a copy of its caller's context instead
+  of the previous task's
 
 ### Security
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -64,6 +64,27 @@ Unreleased
 * `ThreadPool` now runs each task in a copy of its caller's context instead
   of the previous task's
 
+### Authentication and authorization
+
+A new `pelix.security` package adds a transport-neutral notion of a caller:
+identity, groups, roles and permissions. See its reference card for details.
+
+* `pelix.security`: core beans, service specifications (`Authenticator`,
+  `MembershipProvider`, `Authorizer`, `Authorization`) and the current
+  subject
+* `pelix.security.decorators`: declarative `@Allow*`, `@DenyAll` and
+  `@RunAs` decorators
+* `pelix.security.core`: the identity and authorization pipeline
+* `pelix.security.htpasswd`: authentication against Apache `.htpasswd` /
+  `.htgroup` files
+* `pelix.security.policy`: roles and permissions from a TOML file
+
+Nothing is permissive by default.
+
+### Dependencies
+
+* Added `tomli` (Python 3.10 only) and the optional `bcrypt` extra
+
 ### Security
 
 All versions up to 3.2.2 are affected.

--- a/docs/refcards/http.rst
+++ b/docs/refcards/http.rst
@@ -27,23 +27,28 @@ Configuration properties
 
 All implementations of the HTTP service must support the following properties:
 
-========================= ======= =============================================
-Property                  Default Description
-========================= ======= =============================================
-pelix.http.address        0.0.0.0 The address the HTTP server is bound to
-pelix.http.port           8080    The port the HTTP server is bound to
-pelix.http.debug          False   If set, error pages sent to the clients
-                                  contain the stack trace of the error
-pelix.http.max_body_size  1048576 Maximum size, in bytes, of the body of a
-                                  request. A request with a bigger body is
-                                  answered with a 413 error code. A value
-                                  lesser than or equal to 0 removes the limit
-pelix.http.socket_timeout 60      Timeout, in seconds, of the sockets handling
-                                  the requests. A client which takes longer to
-                                  send its request gets a 408 error code. A
-                                  value lesser than or equal to 0 removes the
-                                  timeout
-========================= ======= =============================================
+=============================== ======= ========================================
+Property                        Default Description
+=============================== ======= ========================================
+pelix.http.address              0.0.0.0 The address the HTTP server is bound to
+pelix.http.port                 8080    The port the HTTP server is bound to
+pelix.http.debug                False   If set, error pages sent to the clients
+                                        contain the stack trace of the error
+pelix.http.max_body_size        1048576 Maximum size, in bytes, of the body of a
+                                        request. A request with a bigger body is
+                                        answered with a 413 error code. A value
+                                        lesser than or equal to 0 removes the
+                                        limit
+pelix.http.socket_timeout       60      Timeout, in seconds, of the sockets
+                                        handling the requests. A client which
+                                        takes longer to send its request gets a
+                                        408 error code. A value lesser than or
+                                        equal to 0 removes the timeout
+pelix.http.case_sensitive_paths True    If set, servlet paths are matched
+                                        case-sensitively, as URI paths are
+                                        defined to be. Unset it to restore the
+                                        folding of earlier releases
+=============================== ======= ========================================
 
 .. versionadded:: 3.2.2
    ``pelix.http.max_body_size`` and ``pelix.http.socket_timeout``.
@@ -52,11 +57,44 @@ pelix.http.socket_timeout 60      Timeout, in seconds, of the sockets handling
    and a request without a ``Content-Length`` header blocked its handling
    thread until the client closed the connection.
 
+.. versionadded:: 3.3.0
+   ``pelix.http.case_sensitive_paths``.
+
 .. note:: ``pelix.http.socket_timeout`` is only applied by the synchronous HTTP
    service.
 
    The asynchronous service accepts the property, as it is common to all the
    implementations, but leaves the timeouts of the connections to ``aiohttp``.
+
+Request paths
+-------------
+
+Before a servlet is looked for, the path of a request is normalized: its query
+string is removed, it is percent-decoded, its repeated slashes are collapsed
+and its ``.`` and ``..`` segments are resolved.
+A request whose path holds a control character, or resolves above the root, is
+answered with a 400 error code and never reaches a servlet.
+
+The same normalized path is used to find the servlet and to compute what
+:meth:`~pelix.http.AbstractHTTPServletRequest.get_path` and
+:meth:`~pelix.http.AbstractHTTPServletRequest.get_sub_path` return, so the
+router and the servlet can never disagree about what was requested.
+
+Servlet paths are matched **case-sensitively**: ``/admin`` and ``/Admin`` are
+two different resources, as RFC 3986 defines them to be.
+
+.. versionchanged:: 3.3.0
+   Paths used to be matched after being lowered, and were neither decoded nor
+   resolved. A servlet was given the original path while the server routed on
+   the folded one, so a check made on the path a servlet received could be
+   evaded by changing its case.
+
+.. warning:: A decoded path segment never holds a separator, but it can hold
+   anything else the client encoded.
+
+   A servlet mapping a segment onto a file system, a database key or another
+   name space still has to validate it. The server normalizes the structure of
+   the path; it cannot know what a segment means to the servlet.
 
 .. warning:: ``pelix.http.debug`` must be kept unset in production.
 

--- a/docs/refcards/http_async.rst
+++ b/docs/refcards/http_async.rst
@@ -24,21 +24,40 @@ Configuration properties
 The asynchronous HTTP service supports the same properties as the basic HTTP
 service, described in :ref:`its reference card <refcard_http>`:
 
-========================= ======= =============================================
-Property                  Default Description
-========================= ======= =============================================
-pelix.http.address        0.0.0.0 The address the HTTP server is bound to
-pelix.http.port           8080    The port the HTTP server is bound to
-pelix.http.debug          False   If set, error pages sent to the clients
-                                  contain the stack trace of the error
-pelix.http.max_body_size  1048576 Maximum size, in bytes, of the body of a
-                                  request. A request with a bigger body is
-                                  answered with a 413 error code. A value
-                                  lesser than or equal to 0 removes the limit
-pelix.http.socket_timeout 60      Accepted for compatibility with the basic
-                                  HTTP service, but not applied: the timeouts
-                                  of the connections are left to ``aiohttp``
-========================= ======= =============================================
+=============================== ======= ========================================
+Property                        Default Description
+=============================== ======= ========================================
+pelix.http.address              0.0.0.0 The address the HTTP server is bound to
+pelix.http.port                 8080    The port the HTTP server is bound to
+pelix.http.debug                False   If set, error pages sent to the clients
+                                        contain the stack trace of the error
+pelix.http.max_body_size        1048576 Maximum size, in bytes, of the body of a
+                                        request. A request with a bigger body is
+                                        answered with a 413 error code. A value
+                                        lesser than or equal to 0 removes the
+                                        limit
+pelix.http.socket_timeout       60      Accepted for compatibility with the
+                                        basic HTTP service, but not applied: the
+                                        timeouts of the connections are left to
+                                        ``aiohttp``
+pelix.http.case_sensitive_paths True    If set, servlet paths are matched
+                                        case-sensitively, as URI paths are
+                                        defined to be. Unset it to restore the
+                                        folding of earlier releases
+=============================== ======= ========================================
+
+.. versionadded:: 3.3.0
+   ``pelix.http.case_sensitive_paths``.
+
+Request paths are normalized exactly as they are by the synchronous service:
+see :ref:`its reference card <refcard_http>`.
+Both services now give the router the same raw request target, so they agree on
+the path a servlet is given.
+
+.. versionchanged:: 3.3.0
+   The asynchronous service used to route on the path ``aiohttp`` had already
+   decoded, while the synchronous one routed on the raw target. The two could
+   therefore resolve the same request differently.
 
 Instantiation
 -------------

--- a/docs/refcards/http_async.rst
+++ b/docs/refcards/http_async.rst
@@ -112,6 +112,16 @@ Synchronous Servlet service
 This service is compatible with the synchronous servlets of the HTTP service.
 See :ref:`refcard_http` for more information on the synchronous servlets.
 
+A synchronous servlet is handled in a thread pool, but it runs in a copy of the
+context (see :mod:`contextvars`) of the request which triggered it: a context
+variable set before the dispatch is visible to ``do_GET()`` and the like.
+What the servlet sets stays in that copy: it reaches neither the event loop nor
+the next request handled by the same thread.
+
+.. versionchanged:: 3.3.0
+   The context variables of the request used to be dropped, the servlet running
+   in whatever context the worker thread of the pool happened to hold.
+
 Asynchronous Servlet service
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/refcards/index.md
+++ b/docs/refcards/index.md
@@ -16,6 +16,7 @@ log
 http
 http_async
 http_routing
+security
 remote_services
 rsa
 shell

--- a/docs/refcards/security.rst
+++ b/docs/refcards/security.rst
@@ -1,0 +1,479 @@
+.. _refcard_security:
+.. module:: pelix.security
+
+Authentication and Authorization
+################################
+
+.. versionadded:: 3.3.0
+
+Pelix provides an authentication and authorization layer: who is calling, which
+groups and roles they hold, and what they may do. It is transport-neutral, so the
+same credential store serves an HTTP request, a shell login or a message broker
+connection.
+
+What this layer does not do
+===========================
+
+**Pelix has no code-level permission model.** There is no equivalent of OSGi's
+``ConditionalPermissionAdmin``, no sandbox and no signed-bundle verification. Any
+bundle which gets installed can register a higher-ranked :class:`Authorizer` and take
+over every decision described below, or simply ``import pelix.security`` and call
+:func:`run_as`.
+
+This layer therefore protects against **remote callers, not against locally installed
+bundles**. Read every guarantee below with that boundary in mind.
+
+Four questions, four services
+=============================
+
+============================================== ============================== ==========================
+Question                                       Service                        Shipped implementation
+============================================== ============================== ==========================
+How do I get credentials off this transport?   (transport-specific)           see the HTTP reference card
+Are these credentials valid, and who is it?    :class:`Authenticator`         ``.htpasswd``
+Which groups and roles does this subject have? :class:`MembershipProvider`    ``.htgroup``, policy file
+May this subject do this?                      :class:`Authorizer`            policy file
+============================================== ============================== ==========================
+
+Plus exactly one facade, :class:`Authorization`, which is what application code
+injects or reaches through :func:`use_authorization`.
+
+Bundles
+=======
+
+============================= =============================================================
+Bundle                        What it brings
+============================= =============================================================
+``pelix.security.core``       ``authenticate()``, the :class:`Authorization` facade
+``pelix.security.htpasswd``   an :class:`Authenticator` and a :class:`MembershipProvider`
+``pelix.security.policy``     roles from groups, permissions from roles, and the escape hatch
+============================= =============================================================
+
+:mod:`pelix.security` itself, holding the beans and the current subject, needs no
+bundle at all: it imports the standard library and :mod:`pelix.constants`, and nothing
+else.
+
+The subject
+===========
+
+A :class:`Subject` is a complete, immutable snapshot of who is calling: a person, a
+service account, a device, a peer framework, or the anonymous caller. It carries three
+flat levels:
+
+* ``name`` is the user;
+* ``groups`` is the membership an identity source asserted;
+* ``roles`` is the entitlement level a policy granted from those facts.
+
+There is no membership graph, no nesting and no ``Role`` object. All three levels are
+resolved once, when the subject is authenticated, so a queued execution path carries
+its identity with it and needs no service call at the far end. The price is stated
+next to the benefit: a membership change reaches a caller at their next
+authentication, not immediately.
+
+Identifiers are compared exactly
+--------------------------------
+
+**This layer folds nothing.** No ``lower()``, no ``casefold()``, no Unicode
+normalization, for user names, group names, role names or permission actions,
+anywhere.
+
+The first reason is conformance: the identifiers this layer handles are defined as
+case-sensitive by the specifications which issue them, from the OpenID Connect ``sub``
+claim to OAuth 2.0 scope tokens. The second is that folding can only fail unsafely:
+these are allow-lists, so a match which should not have happened **grants** access,
+and every folding scheme widens the set of strings mapping onto a privileged name.
+
+Folding belongs to whoever owns the matching rule. A provider sitting on a source
+which really is case-insensitive, such as an LDAP directory, applies that rule itself
+and documents the single canonical form it emits.
+
+The cost is direct: a name has to be spelled identically in the identity source, in
+the policy file and in the decorators. ``Dev`` from a directory against ``dev`` in a
+policy file denies, silently, and presents as a policy bug rather than as the data bug
+it is. When a check denies inexplicably, look at the spelling before looking at the
+logic; the policy loader reports the two shapes such a typo usually takes.
+
+The current subject
+===================
+
+The caller is carried in a :class:`contextvars.ContextVar`, and the rule is a
+framework-wide one rather than a security feature:
+
+    **The current subject follows the standard Python context.** Wherever a Python
+    context propagates, the subject propagates; wherever it does not, the subject does
+    not, and the code crossing that boundary copies the context explicitly.
+
+.. autofunction:: get_current_subject
+
+.. autofunction:: run_as
+
+Both are plain module functions, with no service and no bundle required. The asymmetry
+is deliberate: *authorization* needs policy, and therefore a service; *identity* is a
+fact, and it is free. It is also what makes the layer testable::
+
+    with run_as(Subject("alice", roles=frozenset({"admin"}), authenticated=True)):
+        obj.do_the_thing()
+
+No framework, no bundle, no mock.
+
+:class:`~pelix.threadpool.ThreadPool` and the asynchronous HTTP service both carry the
+context across their thread boundaries, so a subject published before a task is queued
+is visible inside it.
+
+Permissions
+===========
+
+A :class:`Permission` is an action, optionally scoped to a resource:
+``jobs.submit``, ``jobs.submit:queue-a``. Strings are parsed at the edges, once, so a
+single type flows through the services.
+
+The matching rule is small and complete. An action matches in one of three ways:
+
+=============== =============================================================
+Grant action    Matches
+=============== =============================================================
+``jobs.submit`` exactly ``jobs.submit``
+``jobs.*``      every action starting with ``jobs.``, at any depth, but not
+                ``jobs`` itself
+``*``           every action. The only all-grant form
+=============== =============================================================
+
+And a resource in one of four:
+
+================ ===================== ==============================================
+Grant resource   Request resource      Result
+================ ===================== ==============================================
+absent           anything              match: the grant is not resource-scoped
+``*``            anything              match
+``queue-a``      ``queue-a``           match
+``queue-a``      absent, or any other  no match
+================ ===================== ==============================================
+
+A grant scoped to a resource therefore never satisfies a request naming none:
+``jobs.submit:queue-a`` does not imply ``jobs.submit``. That is the safe direction.
+
+Decorators
+==========
+
+Read every one of them as **"allow only"**: ``@AllowGroup("dev")`` means "allow only
+the dev group". Each decorator narrows who can reach the target, and the names listed
+inside one decorator are alternatives::
+
+    @AllowAuthenticated                  # allow only authenticated subjects
+    @AllowGroup("dev", "ops")            # allow only these groups (any of them)
+    @AllowRole("admin")                  # allow only these roles (any of them)
+    @AllowPermission("jobs.submit")      # parsed once, at decoration time
+    @AllowAll                            # no narrowing: overrides a class-level default
+    @DenyAll                             # total narrowing
+    @RunAs(Subject("batch", roles=frozenset({"operator"})))
+
+The rule follows from that reading: **any-of within one decorator, all-of when they
+are stacked, and a method-level declaration replaces a class-level one entirely.**
+Stacking ``@AllowGroup("dev")`` and ``@AllowRole("admin")`` therefore means "only
+members of ``dev`` who also hold ``admin``".
+
+``@AllowAuthenticated``, ``@AllowAll`` and ``@DenyAll`` take no argument and are
+written bare, without parentheses. The others always take at least one. No decorator
+supports both forms, and applying an argument-taking one bare raises ``TypeError`` at
+import time.
+
+Applied to a class, a decorator sets the default of every function defined **in that
+class body** whose name does not start with an underscore. It does not reach inherited
+methods, and a method which carries its own declaration keeps it.
+
+There is no ``@AllowUser``. Deployment configuration may legitimately name a user;
+source code should not.
+
+What a refusal raises
+---------------------
+
+The choice between the two exceptions is mechanical:
+
+* the current subject is **not authenticated**: :class:`AuthenticationRequired`. Over
+  HTTP this becomes a 401 with a challenge, so a client can retry with credentials;
+* the current subject **is authenticated** but does not satisfy the declaration:
+  :class:`AccessDenied`, which becomes a 403. Retrying with the same credentials is
+  pointless and the status says so.
+
+``@DenyAll`` always raises the second, even for an anonymous subject: no credential
+would help, so offering a challenge would be a lie.
+
+``@RunAs`` is privilege escalation by construction: anyone who can import it can
+elevate. In a framework with no sandbox it is a readability tool, not a security
+boundary. There is no built-in all-powerful subject, which keeps it at worst a lateral
+move: a system identity is an ordinary ``Subject("system", roles=frozenset({"system"}))``
+whose authority comes from the policy file.
+
+Fail closed
+-----------
+
+================================================== ==========================================
+Situation                                          Behaviour
+================================================== ==========================================
+``pelix.security.core`` not started                every decorator but ``@AllowPermission``
+                                                   still works: they are pure context-variable
+                                                   operations. ``@AllowPermission`` denies,
+                                                   with one warning per distinct permission
+Started, no :class:`Authorizer` registered         deny, with one warning
+Genuinely permissive wanted                        instantiate
+                                                   ``pelix.security.authorizer.allow-all.factory``,
+                                                   which warns when it validates
+================================================== ==========================================
+
+You cannot become permissive by accident. State the consequence loudly in your own
+documentation: **installing a library whose methods carry ``@AllowPermission``, and
+not starting the bundle, means those methods raise.**
+
+The pipeline
+============
+
+``pelix.security.core.authenticate(credentials)`` turns credentials into a subject:
+
+1. every :class:`Authenticator` accepting this kind of credentials is consulted in
+   ``service.ranking`` order;
+2. every :class:`MembershipProvider` contributes groups, and the results are unioned;
+3. the subject is rebuilt with those groups, and only then does every provider
+   contribute roles;
+4. the subject is returned, authenticated, with ``method`` left unset for the
+   transport to stamp.
+
+Step 3 is two passes rather than one, and that is load-bearing: it is what lets the
+policy file grant a role from a group a *different* provider asserted. With a single
+pass the policy would look at a subject whose groups are still empty and answer
+nothing.
+
+The three-state authenticator contract
+--------------------------------------
+
+This is the most important detail of the pipeline. Two outcomes are not enough:
+
+* returning a :class:`Subject` means success: stop;
+* returning ``None`` means **abstain**: not my credential kind, not my user, try the
+  next one;
+* raising :class:`AuthenticationFailed` means **presented and wrong**: stop, and do
+  not consult lower-ranked authenticators.
+
+Without the third state, a low-ranked fallback store silently becomes an oracle for
+credentials a higher-ranked store already rejected: user ``admin`` exists in the main
+store with one password and in an emergency ``.htpasswd`` with another, and the second
+one keeps working forever.
+
+An :class:`Authenticator` must declare the credential kinds it accepts, in its
+``pelix.security.credentials`` service property. One which does not is never
+consulted.
+
+Combining authorizers
+---------------------
+
+One fixed, non-configurable rule: **any DENY denies; otherwise any PERMIT permits;
+otherwise deny.** :attr:`Decision.ABSTAIN` is what lets independent policies compose.
+An authorizer which raises denies: one which cannot decide has not decided.
+
+The ``.htpasswd`` store
+=======================
+
+``pelix.security.htpasswd`` provides both an :class:`Authenticator` over a password
+file and a :class:`MembershipProvider` over a matching ``.htgroup``.
+
+============================================ =========================================
+Property                                     Meaning
+============================================ =========================================
+``pelix.security.htpasswd.file``             path of the password file (mandatory)
+``pelix.security.htpasswd.groups``           path of the group file
+``pelix.security.htpasswd.allow_plaintext``  accept an unrecognized hash as a plaintext
+                                             password. Default: ``False``
+============================================ =========================================
+
+Hash formats
+------------
+
+============================ ==========================================================
+Format                       Support
+============================ ==========================================================
+``$5$``, ``$6$`` SHA-crypt   supported, and recommended. ``htpasswd -2``, ``htpasswd -5``
+``$apr1$`` Apache MD5        supported. ``htpasswd -m``
+``{SHA}`` base64 SHA-1       supported, with a warning: unsalted and unstretched
+``$2a$``, ``$2b$``, ``$2y$`` bcrypt, when the optional ``iPOPO[bcrypt]`` extra is
+                             installed
+DES crypt (13 characters)    refused: eight-character truncation, twelve-bit salt
+anything else                treated as a plaintext password, refused unless allowed
+============================ ==========================================================
+
+The ``rounds=`` parameter of a SHA-crypt hash is capped at 100000. The format allows
+999999999, which one login would turn into minutes of CPU.
+
+The whole file is parsed when it is loaded, not entry by entry at login. An entry this
+build cannot verify is reported with its file and line number, and its user is left
+**absent** rather than present and unverifiable: a load-time failure is found by the
+operator at deploy time. A world-readable password file is reported too.
+
+An unknown user is checked against a dummy hash before the store abstains, so that it
+does not answer visibly faster than a known one. One residual leak cannot be closed
+there and is worth knowing: with several stores registered, an unknown user is
+consulted against every one of them while a known user stops at the first.
+
+The policy file
+===============
+
+``pelix.security.policy`` reads a TOML file granting roles from users and groups, and
+permissions to roles:
+
+.. code-block:: toml
+
+    [roles.admin]
+    users  = ["thomas"]
+    groups = ["dev-leads"]
+
+    [roles.operator]
+    groups = ["dev", "ops"]
+
+    [permissions]
+    admin    = ["jobs.*", "config.*"]
+    operator = ["jobs.read", "jobs.submit"]
+
+Its path is the ``pelix.security.policy.file`` property.
+
+The format is TOML because **TOML keys are case-sensitive by specification**, and role
+names are keys here: an INI file would have folded them in the very component which
+must fold nothing. Typed tables also say whether a name is a user or a group in the
+schema, and a duplicate key is a parse error rather than a silently kept last one.
+
+Two things are reported when the file is loaded, and both are worth acting on:
+
+* every grant containing a ``*``, naming the file and the role. A wildcard is one typo
+  away from full access;
+* every **dangling reference**: a role granted to somebody but never given a
+  permission, and a permission granted to a role nobody holds. Most spelling mistakes
+  produce one of those two shapes.
+
+This authorizer never returns ``DENY``, only ``PERMIT`` or ``ABSTAIN``: the format
+expresses grants only, so a policy file can never veto a permission another, looser
+authorizer allows. There is no implicit all-grant either: an empty ``[permissions]``
+table denies everything.
+
+Reloading
+=========
+
+Both bundles register as File Install listeners (see :doc:`fileinstall`), so writing
+the file is enough. Without that bundle the files are read once at validation, which
+is graceful degradation rather than a failure.
+
+Two caveats come with it. File Install watches a **whole folder**, so the password
+file belongs in its own directory. And on a parse failure, a shape failure, an empty
+file or an unreadable one, **the previous table is kept** and an error is logged: an
+empty file is far more likely a partial write than an intentional revocation of
+everyone. A successfully parsed file with a user removed does revoke that user.
+
+Worked example
+==============
+
+``/etc/pelix/auth/.htpasswd``, in its own directory:
+
+.. code-block:: text
+
+    thomas:$6$rounds=10000$FGkY6bLp$1qE...
+
+``/etc/pelix/auth/.htgroup``:
+
+.. code-block:: text
+
+    # groupname: user1 user2
+    dev-leads: thomas
+
+``/etc/pelix/auth/policy.toml``:
+
+.. code-block:: toml
+
+    [roles.admin]
+    groups = ["dev-leads"]
+
+    [permissions]
+    admin = ["jobs.*"]
+
+The ``.ipopo`` initialization file (see :doc:`init_config`):
+
+.. code-block:: json
+
+    {
+      "bundles": [
+        "pelix.ipopo.core",
+        "pelix.services.fileinstall",
+        "pelix.security.core",
+        "pelix.security.htpasswd",
+        "pelix.security.policy"
+      ],
+      "components": [
+        {"factory": "pelix.security.htpasswd.factory", "name": "users",
+         "properties": {"pelix.security.htpasswd.file": "/etc/pelix/auth/.htpasswd",
+                        "pelix.security.htpasswd.groups": "/etc/pelix/auth/.htgroup"}},
+        {"factory": "pelix.security.policy.file.factory", "name": "policy",
+         "properties": {"pelix.security.policy.file": "/etc/pelix/auth/policy.toml"}}
+      ]
+    }
+
+And, in a component::
+
+    import pelix.security.core
+    from pelix.security import UsernamePassword, run_as
+    from pelix.security.decorators import AllowPermission
+
+    @AllowPermission("jobs.submit")
+    def submit_job(name):
+        ...
+
+    subject = pelix.security.core.authenticate(UsernamePassword("thomas", "..."))
+    # Subject(name='thomas', groups=['dev-leads'], roles=['admin'], ...)
+
+    with run_as(subject):
+        submit_job("nightly")
+
+API
+===
+
+Beans
+-----
+
+.. autoclass:: Subject
+   :members:
+
+.. autoclass:: Credentials
+   :members:
+
+.. autoclass:: UsernamePassword
+   :members:
+
+.. autoclass:: Permission
+   :members:
+
+.. autoclass:: Decision
+   :members:
+
+Services
+--------
+
+.. autoclass:: Authenticator
+   :members:
+
+.. autoclass:: MembershipProvider
+   :members:
+
+.. autoclass:: Authorizer
+   :members:
+
+.. autoclass:: Authorization
+   :members:
+
+.. autofunction:: use_authorization
+
+Exceptions
+----------
+
+.. autoclass:: SecurityError
+.. autoclass:: AuthenticationFailed
+.. autoclass:: AuthenticationRequired
+.. autoclass:: AccessDenied
+
+The pipeline
+------------
+
+.. autofunction:: pelix.security.core.authenticate

--- a/pelix/http/__init__.py
+++ b/pelix/http/__init__.py
@@ -106,6 +106,17 @@ Avoids a slow client to keep a request handling thread busy forever. A value
 lesser than or equal to 0 removes the timeout.
 """
 
+# ... case sensitivity of the servlet paths
+HTTP_CASE_SENSITIVE_PATHS = "pelix.http.case_sensitive_paths"
+"""
+Whether servlet paths are matched case-sensitively (boolean, True by default).
+
+URI paths are case-sensitive (RFC 3986), so ``/Admin`` and ``/admin`` are two
+different resources. Setting this property to False restores the folding of
+earlier versions, in which they were the same one: it is provided only to give
+an existing deployment time to spell its paths as it registers them.
+"""
+
 # HTTP servlet constants
 HTTP_SERVLET = "pelix.http.servlet"
 """ HTTP Servlet service specification """
@@ -309,7 +320,13 @@ class AbstractHTTPServletRequest(ABC):
     @abstractmethod
     def get_path(self) -> str:
         """
-        Returns the request full path
+        Returns the request full path, normalized.
+
+        The path is percent-decoded, its query string is removed, its repeated
+        slashes are collapsed and its ``.`` and ``..`` segments are resolved.
+        A segment therefore never holds a separator. Everything else the client
+        encoded reaches the servlet unchanged, so a servlet mapping a segment
+        onto a file system or another name space still has to validate it.
 
         :return: A request full path (string)
         """
@@ -318,7 +335,10 @@ class AbstractHTTPServletRequest(ABC):
     @abstractmethod
     def get_prefix_path(self) -> str:
         """
-        Returns the path to the servlet root
+        Returns the path to the servlet root, as the servlet was registered.
+
+        Servlet paths are matched case-sensitively unless
+        :const:`HTTP_CASE_SENSITIVE_PATHS` says otherwise.
 
         :return: A request path (string)
         """
@@ -327,7 +347,10 @@ class AbstractHTTPServletRequest(ABC):
     @abstractmethod
     def get_sub_path(self) -> str:
         """
-        Returns the servlet-relative path, i.e. after the prefix
+        Returns the servlet-relative path, i.e. after the prefix.
+
+        It is cut out of the path :meth:`get_path` returns, so it carries the
+        same guarantees.
 
         :return: A request path (string)
         """
@@ -543,7 +566,13 @@ class AbstractAsyncHTTPServletRequest(ABC):
     @abstractmethod
     def get_path(self) -> str:
         """
-        Returns the request full path
+        Returns the request full path, normalized.
+
+        The path is percent-decoded, its query string is removed, its repeated
+        slashes are collapsed and its ``.`` and ``..`` segments are resolved.
+        A segment therefore never holds a separator. Everything else the client
+        encoded reaches the servlet unchanged, so a servlet mapping a segment
+        onto a file system or another name space still has to validate it.
 
         :return: A request full path (string)
         """
@@ -552,7 +581,10 @@ class AbstractAsyncHTTPServletRequest(ABC):
     @abstractmethod
     def get_prefix_path(self) -> str:
         """
-        Returns the path to the servlet root
+        Returns the path to the servlet root, as the servlet was registered.
+
+        Servlet paths are matched case-sensitively unless
+        :const:`HTTP_CASE_SENSITIVE_PATHS` says otherwise.
 
         :return: A request path (string)
         """
@@ -561,7 +593,10 @@ class AbstractAsyncHTTPServletRequest(ABC):
     @abstractmethod
     def get_sub_path(self) -> str:
         """
-        Returns the servlet-relative path, i.e. after the prefix
+        Returns the servlet-relative path, i.e. after the prefix.
+
+        It is cut out of the path :meth:`get_path` returns, so it carries the
+        same guarantees.
 
         :return: A request path (string)
         """

--- a/pelix/http/_base.py
+++ b/pelix/http/_base.py
@@ -37,6 +37,7 @@ import logging
 import re
 import socket
 import threading
+import urllib.parse
 import uuid
 from dataclasses import dataclass
 from typing import Any, cast
@@ -75,6 +76,9 @@ DEFAULT_REQUEST_QUEUE_SIZE = 5
 _MULTIPLE_SLASHES = re.compile("/+")
 """ Matches a sequence of consecutive slashes """
 
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+""" Matches a control character, which has no place in a decoded request path """
+
 AnyServlet = http.Servlet | http.AsyncServlet | http.WebSocketHandler
 """ Any kind of servlet service (sync, async, web socket, ...) """
 
@@ -112,13 +116,45 @@ def normalize_max_body_size(value: Any) -> int | None:
 
 def normalize_request_path(raw_path: str) -> str:
     """
-    Normalizes the path of an incoming request: removes the query string and
-    collapses the sequences of consecutive slashes.
+    Normalizes the path of an incoming request: removes the query string,
+    decodes the percent-encoded characters, collapses the sequences of
+    consecutive slashes and resolves the ``.`` and ``..`` segments.
 
-    :param raw_path: The raw request path
+    The result is the single path used both to look for a servlet and to
+    compute the path given to that servlet, so that the two can never disagree.
+
+    This must be called once, on the raw request path: as it decodes, applying
+    it to its own result would decode a second time.
+
+    :param raw_path: The raw request path, as sent by the client
     :return: The path to use to look for a servlet
+    :raise ValueError: The path holds a control character or escapes the root
     """
-    return _MULTIPLE_SLASHES.sub("/", raw_path.split("?", 1)[0])
+    path = urllib.parse.unquote(raw_path.split("?", 1)[0])
+    if _CONTROL_CHARS.search(path):
+        raise ValueError("Control character in request path")
+
+    path = _MULTIPLE_SLASHES.sub("/", path)
+    trailing_slash = path.endswith("/") and path != "/"
+
+    segments: list[str] = []
+    for segment in path.split("/"):
+        if not segment or segment == ".":
+            continue
+
+        if segment == "..":
+            if not segments:
+                # Refuse the request instead of silently clamping it to the root
+                raise ValueError("Request path escapes the root")
+            segments.pop()
+        else:
+            segments.append(segment)
+
+    normalized = f"/{'/'.join(segments)}"
+    if trailing_slash and normalized != "/":
+        normalized += "/"
+
+    return normalized
 
 
 def compute_sub_path(full_path: str, prefix: str) -> str:
@@ -162,6 +198,9 @@ class RequestRouting:
     servlet_type: http.ServletType
     """ The kind of servlet which must handle the request """
 
+    error: int | None = None
+    """ Error code to answer with, when the path itself has been refused """
+
 
 # ------------------------------------------------------------------------------
 
@@ -171,6 +210,7 @@ class RequestRouting:
 @Property("_debug_errors", http.HTTP_DEBUG_ERRORS, False)
 @Property("_max_body_size", http.HTTP_MAX_BODY_SIZE, 1024 * 1024)
 @Property("_socket_timeout", http.HTTP_SOCKET_TIMEOUT, 60.0)
+@Property("_case_sensitive_paths", http.HTTP_CASE_SENSITIVE_PATHS, True)
 @Property("_uses_ssl", http.HTTP_USES_SSL, False)
 @Property("_cert_file", http.HTTPS_CERT_FILE, None)
 @Property("_key_file", http.HTTPS_KEY_FILE, None)
@@ -191,6 +231,7 @@ class AbstractHttpService(http.HTTPService):
         self._debug_errors = False
         self._max_body_size: int | None = 1024 * 1024
         self._socket_timeout: float | None = 60.0
+        self._case_sensitive_paths = True
         self._uses_ssl = False
         self._extra: dict[str, Any] | None = None
         self._instance_name: str | None = None
@@ -387,6 +428,15 @@ class AbstractHttpService(http.HTTPService):
         """
         return sorted(self._servlets)
 
+    def _servlet_key(self, path: str) -> str:
+        """
+        Computes the key a path is stored under in the servlets registry.
+
+        :param path: A servlet or request path
+        :return: The path itself, unless the folding of paths has been re-enabled
+        """
+        return path if self._case_sensitive_paths else path.lower()
+
     def get_servlet(self, path: str | None) -> tuple[Any, dict[str, Any], str, http.ServletType] | None:
         """
         Retrieves the servlet matching the given path and its parameters.
@@ -399,8 +449,7 @@ class AbstractHttpService(http.HTTPService):
             # No path, nothing to return
             return None
 
-        # Use lower case for comparison
-        path = path.lower()
+        path = self._servlet_key(path)
 
         if path[-1] != "/":
             # Add a trailing slash
@@ -436,9 +485,16 @@ class AbstractHttpService(http.HTTPService):
 
         :param raw_path: The raw request path, as given by the client
         :return: The result of the routing (never None). Its ``servlet`` is
-                 None if no servlet matches the path.
+                 None if no servlet matches the path, and its ``error`` is set
+                 if the path itself has been refused.
         """
-        normalized_path = normalize_request_path(raw_path)
+        try:
+            normalized_path = normalize_request_path(raw_path)
+        except ValueError as ex:
+            # Malformed path: it is answered before any servlet is looked for
+            self.log(logging.WARNING, "Refused request path %r: %s", raw_path, ex)
+            return RequestRouting(raw_path, None, {}, "", http.ServletType.SYNC, error=400)
+
         found_servlet = self.get_servlet(normalized_path)
         if found_servlet is None:
             return RequestRouting(normalized_path, None, {}, "", http.ServletType.SYNC)
@@ -481,8 +537,7 @@ class AbstractHttpService(http.HTTPService):
         if not path or path[0] != "/":
             raise ValueError(f"Invalid path given to register the servlet: {path}")
 
-        # Use lower-case paths
-        path = path.lower()
+        path = self._servlet_key(path)
 
         # Prepare the parameters
         if parameters is None:
@@ -565,8 +620,7 @@ class AbstractHttpService(http.HTTPService):
                 # Invalid path
                 return False
 
-            # Always use lower case to compare paths
-            path = path.lower()
+            path = self._servlet_key(path)
 
             with self._lock:
                 # Notify the servlet

--- a/pelix/http/basic.py
+++ b/pelix/http/basic.py
@@ -100,6 +100,7 @@ class _HTTPServletRequest(http.AbstractHTTPServletRequest):
         :param max_body_size: Maximum accepted size of the body, in bytes
         """
         self._handler = request_handler
+        self._full_path = full_path
         self._prefix = prefix
         self.max_body_size = max_body_size
 
@@ -134,9 +135,9 @@ class _HTTPServletRequest(http.AbstractHTTPServletRequest):
 
     def get_path(self) -> str:
         """
-        Retrieves the request full path
+        Retrieves the request full path, normalized
         """
-        return self._handler.path
+        return self._full_path
 
     def get_prefix_path(self) -> str:
         """
@@ -284,6 +285,10 @@ class _RequestHandler(BaseHTTPRequestHandler):
 
         # Get the corresponding servlet
         routing = self._service.resolve_request(self.path)
+        if routing.error is not None:
+            # The path itself has been refused: no servlet is looked for
+            return self.send_bad_path_response
+
         servlet = routing.servlet
         if servlet is not None and hasattr(servlet, name):
             # Prepare the helpers
@@ -314,7 +319,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
             return wrapper
 
         # Return the super implementation if needed
-        return self.send_no_servlet_response
+        return lambda: self.send_no_servlet_response(routing.path)
 
     def log_error(self, format: str, *args: Any, **kwargs: Any) -> None:
         """
@@ -328,13 +333,23 @@ class _RequestHandler(BaseHTTPRequestHandler):
         """
         self._service.log(logging.DEBUG, '"%s" %s', self.requestline, code)
 
-    def send_no_servlet_response(self) -> None:
+    def send_no_servlet_response(self, path: str) -> None:
         """
         Default response sent when no servlet is found for the requested path
+
+        :param path: The normalized path the servlet was looked for
         """
         # Use the helper to send the error page
         response = _HTTPServletResponse(self)
-        response.send_content(404, self._service.make_not_found_page(self.path))
+        response.send_content(404, self._service.make_not_found_page(path))
+
+    def send_bad_path_response(self) -> None:
+        """
+        Response sent when the requested path has been refused, before any
+        servlet has been looked for
+        """
+        response = _HTTPServletResponse(self)
+        response.send_content(400, "<html><body><h1>Bad Request</h1></body></html>")
 
     def send_too_large_response(
         self, response: http.AbstractHTTPServletResponse, error: http.BodyTooLargeError

--- a/pelix/http/basic_async.py
+++ b/pelix/http/basic_async.py
@@ -29,6 +29,8 @@ Provides an implementation of the Pelix HTTP service based on aiohttp.
 
 import asyncio
 import concurrent.futures
+import contextvars
+import functools
 import io
 import logging
 import ssl
@@ -934,10 +936,12 @@ class AsyncHttpServiceImpl(AbstractHttpService):
                         servlet_request = _SyncHTTPServletRequest(request, path, prefix, content)
                         servlet_response = _SyncHTTPServletResponse(request, self._loop)
 
-                        # Handle the request in the executor
+                        # Copy the context here: unlike asyncio.to_thread, run_in_executor does not carry it
                         handler_method = getattr(servlet, sync_name)
+                        context = contextvars.copy_context()
                         await self._loop.run_in_executor(
-                            self._executor, handler_method, servlet_request, servlet_response
+                            self._executor,
+                            functools.partial(context.run, handler_method, servlet_request, servlet_response),
                         )
                         return servlet_response.to_aiohttp_response()
 

--- a/pelix/http/basic_async.py
+++ b/pelix/http/basic_async.py
@@ -101,6 +101,7 @@ class _SyncHTTPServletRequest(http.AbstractHTTPServletRequest):
         :param content: The request content
         """
         self._request = request
+        self._full_path = full_path
         self._prefix = prefix
         self._content = content
 
@@ -142,9 +143,9 @@ class _SyncHTTPServletRequest(http.AbstractHTTPServletRequest):
 
     def get_path(self) -> str:
         """
-        Retrieves the request full path
+        Retrieves the request full path, normalized
         """
-        return self._request.path
+        return self._full_path
 
     def get_prefix_path(self) -> str:
         """
@@ -341,6 +342,7 @@ class _AsyncHTTPServletRequest(http.AbstractAsyncHTTPServletRequest):
         :param max_body_size: Maximum accepted size of the body, in bytes
         """
         self._request = request
+        self._full_path = full_path
         self._prefix = prefix
         self.max_body_size = max_body_size
 
@@ -382,9 +384,9 @@ class _AsyncHTTPServletRequest(http.AbstractAsyncHTTPServletRequest):
 
     def get_path(self) -> str:
         """
-        Retrieves the request full path
+        Retrieves the request full path, normalized
         """
-        return self._request.path
+        return self._full_path
 
     def get_prefix_path(self) -> str:
         """
@@ -885,8 +887,14 @@ class AsyncHttpServiceImpl(AbstractHttpService):
             # No executor available, cannot handle the request
             return aiohttp.web.Response(status=503, text="Service unavailable")
 
-        # Get the corresponding servlet
-        routing = self.resolve_request(request.path)
+        # Use the raw path: aiohttp already decoded request.path, normalizing it again would double-decode
+        routing = self.resolve_request(request.raw_path)
+        if routing.error is not None:
+            # The path itself has been refused: no servlet is looked for
+            return aiohttp.web.Response(
+                status=400, text="<html><body><h1>Bad Request</h1></body></html>", content_type="text/html"
+            )
+
         path = routing.path
         servlet = routing.servlet
         if servlet is not None:

--- a/pelix/remote/dispatcher.py
+++ b/pelix/remote/dispatcher.py
@@ -653,12 +653,12 @@ class RegistryServlet(pelix.remote.RemoteServiceDispatcherServlet):
         :param request: Request handler
         :param response: Response handler
         """
-        # Normalize the path
-        path_parts = [part for part in request.get_path().split("/") if part]
+        # Route on the normalized sub path: segment counting would shift with an extra slash or dot
+        path_parts = [part for part in request.get_sub_path().split("/") if part]
+        if not path_parts:
+            response.send_content(404, "No action given", "text/plain")
+            return
 
-        # Remove the servlet part
-        servlet_parts = [part for part in self._path.split("/") if part]
-        path_parts = path_parts[len(servlet_parts) :]
         action = path_parts[0]
 
         data: Any
@@ -712,9 +712,9 @@ class RegistryServlet(pelix.remote.RemoteServiceDispatcherServlet):
         :param request: Request handler
         :param response: Response handler
         """
-        # Split the path
-        path_parts = request.get_path().split("/")
-        if path_parts[-1] != "endpoints":
+        # Split the sub path, ignoring a trailing slash
+        path_parts = [part for part in request.get_sub_path().split("/") if part]
+        if path_parts != ["endpoints"]:
             # Bad path
             response.send_content(404, "Unhandled path", "text/plain")
             return

--- a/pelix/security/__init__.py
+++ b/pelix/security/__init__.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Pelix security package.
+
+Defines the identity beans, the exceptions, the service specifications and the current
+subject of the authentication and authorization layer.
+
+This module is importable with no framework running: like :mod:`pelix.constants` and
+:mod:`pelix.utilities`, it imports nothing but the standard library and
+:mod:`pelix.constants`. That is what lets a credential store or a set of decorated
+methods be unit-tested with a bare ``import``.
+
+**Stated non-goal**: Pelix has no code-level permission model, no sandbox and no
+signed-bundle verification. Any bundle which gets installed can register a
+higher-ranked :class:`Authorizer`, or simply import :func:`run_as`. This layer protects
+against remote callers, not against locally installed bundles.
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+:version: 3.2.2
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import contextlib
+import contextvars
+from collections.abc import Generator, Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol
+
+from pelix.constants import BundleException, Specification
+
+if TYPE_CHECKING:
+    from pelix.framework import BundleContext
+
+# Module version
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+# ------------------------------------------------------------------------------
+
+SERVICE_AUTHENTICATOR = "pelix.security.authenticator"
+""" Specification of a credential store: are these credentials valid, and who is it """
+
+SERVICE_MEMBERSHIP_PROVIDER = "pelix.security.membership"
+""" Specification of a provider of the groups and roles of a subject """
+
+SERVICE_AUTHORIZER = "pelix.security.authorizer"
+""" Specification of a policy: may this subject do this """
+
+SERVICE_AUTHORIZATION = "pelix.security.authorization"
+""" Specification of the authorization facade, the service application code uses """
+
+# ------------------------------------------------------------------------------
+
+PROP_CREDENTIAL_KINDS = "pelix.security.credentials"
+""" Kinds of credentials an Authenticator accepts, as an iterable of strings """
+
+PROP_HTPASSWD_FILE = "pelix.security.htpasswd.file"
+""" Path to the .htpasswd file of the htpasswd component """
+
+PROP_HTPASSWD_GROUPS = "pelix.security.htpasswd.groups"
+""" Path to the .htgroup file of the htpasswd component """
+
+PROP_HTPASSWD_PLAINTEXT = "pelix.security.htpasswd.allow_plaintext"
+""" Accept plaintext passwords in a .htpasswd file. Default: False """
+
+PROP_POLICY_FILE = "pelix.security.policy.file"
+""" Path to the TOML policy file of the policy component """
+
+# ------------------------------------------------------------------------------
+
+FACTORY_HTPASSWD = "pelix.security.htpasswd.factory"
+""" Name of the component factory of the .htpasswd credential store """
+
+FACTORY_POLICY_FILE = "pelix.security.policy.file.factory"
+""" Name of the component factory of the TOML policy file """
+
+FACTORY_ALLOW_ALL = "pelix.security.authorizer.allow-all.factory"
+""" Name of the component factory of the allow-all Authorizer escape hatch """
+
+# ------------------------------------------------------------------------------
+
+ATTRIBUTE_SESSION_ID = "pelix.security.session.id"
+""" Reserved Subject.attributes key, holding the handle of a session mechanism """
+
+TOPIC_AUTH_SUCCESS = "pelix/security/AUTH_SUCCESS"
+""" EventAdmin topic of a successful authentication """
+
+TOPIC_AUTH_FAILURE = "pelix/security/AUTH_FAILURE"
+""" EventAdmin topic of a rejected authentication """
+
+TOPIC_ACCESS_DENIED = "pelix/security/ACCESS_DENIED"
+""" EventAdmin topic of a refused authorization """
+
+# ------------------------------------------------------------------------------
+
+
+class SecurityError(Exception):
+    """
+    Root of the security exception family
+    """
+
+
+class AuthenticationFailed(SecurityError):
+    """
+    Credentials were presented and are wrong
+    """
+
+
+class AuthenticationRequired(SecurityError):
+    """
+    The caller is anonymous and needs a challenge: an HTTP transport answers 401
+    """
+
+
+class AccessDenied(SecurityError):
+    """
+    The caller is authenticated but not permitted: an HTTP transport answers 403
+    """
+
+
+# ------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Subject:
+    """
+    A complete and immutable snapshot of who is calling: a person, a service account, a
+    device, a peer framework or the anonymous caller.
+
+    The three levels are flat and immutable: ``name`` is the user, ``groups`` is the
+    membership asserted by an identity source, and ``roles`` is the entitlement level
+    granted from those facts. There is no membership graph and no nesting.
+
+    Every identifier is compared exactly, with no case folding and no Unicode
+    normalization: a source whose matching rule is case-insensitive applies that rule
+    itself and emits a single documented canonical form.
+    """
+
+    name: str
+    groups: frozenset[str] = frozenset()
+    roles: frozenset[str] = frozenset()
+    # compare=False: a Mapping is unhashable, so attributes must be excluded to keep Subject hashable
+    attributes: Mapping[str, Any] = field(default_factory=dict, compare=False)
+    authenticated: bool = False
+    method: str | None = None
+    """ Name of the mechanism which authenticated this subject: "basic", "oidc", ... """
+
+    def __post_init__(self) -> None:
+        # frozen=True is not immutability: the caller may still hold the mapping it gave
+        if not isinstance(self.attributes, MappingProxyType):
+            object.__setattr__(self, "attributes", MappingProxyType(dict(self.attributes)))
+
+        object.__setattr__(self, "groups", frozenset(self.groups))
+        object.__setattr__(self, "roles", frozenset(self.roles))
+
+    def __repr__(self) -> str:
+        # Name the attribute keys only: printing their values could leak raw claims or session handles
+        return (
+            f"Subject(name={self.name!r}, groups={sorted(self.groups)}, "
+            f"roles={sorted(self.roles)}, attributes=[{', '.join(sorted(self.attributes))}], "
+            f"authenticated={self.authenticated}, method={self.method!r})"
+        )
+
+
+ANONYMOUS = Subject("anonymous")
+""" The caller of a request which carried no identity """
+
+
+@dataclass(frozen=True)
+class Credentials:
+    """
+    Base class of what a transport extracted, before it is validated.
+
+    ``KIND`` is what an :class:`Authenticator` is selected on: it registers with the
+    kinds it accepts in its :data:`PROP_CREDENTIAL_KINDS` property, and the core builds
+    an LDAP filter from the kind of the object it was handed.
+    """
+
+    KIND: ClassVar[str] = "unknown"
+
+
+@dataclass(frozen=True)
+class UsernamePassword(Credentials):
+    """
+    A user name and a password, as HTTP Basic or a shell login produces them
+    """
+
+    KIND: ClassVar[str] = "password"
+
+    username: str
+    # repr=False, or the first traceback which touches this prints the password
+    password: str = field(repr=False)
+
+
+@dataclass(frozen=True)
+class Permission:
+    """
+    One action, optionally scoped to a resource: ``jobs.submit``, ``jobs.submit:queue-a``.
+
+    Strings are parsed at the edges, once, so that a single type flows through the
+    service specifications.
+    """
+
+    action: str
+    resource: str | None = None
+
+    @classmethod
+    def parse(cls, spec: str) -> "Permission":
+        """
+        Parses a permission specification.
+
+        :param spec: An action, optionally followed by ``:`` and a resource
+        :return: The parsed permission
+        :raise ValueError: The action half is empty
+        """
+        action, separator, resource = spec.partition(":")
+        if not action:
+            raise ValueError(f"Empty permission action in {spec!r}")
+
+        return cls(action, resource if separator else None)
+
+    def implies(self, other: "Permission") -> bool:
+        """
+        Tells if this permission, read as a grant, satisfies the given request.
+
+        This is a pure string-matching helper on the bean, deliberately not the
+        authorization decision: that one is :meth:`Authorization.is_permitted`.
+
+        :param other: The requested permission
+        :return: True if the grant covers the request
+        """
+        return self.__action_implies(other.action) and self.__resource_implies(other.resource)
+
+    def __action_implies(self, action: str) -> bool:
+        """
+        Matches the action half: exactly, by prefix, or the single all-grant form
+        """
+        if self.action == "*":
+            return True
+
+        if self.action.endswith(".*"):
+            # "jobs.*" covers "jobs.submit" and "jobs.queue.drain", but not "jobs"
+            return action.startswith(self.action[:-1])
+
+        return self.action == action
+
+    def __resource_implies(self, resource: str | None) -> bool:
+        """
+        Matches the resource half. A grant scoped to a resource never satisfies a
+        request naming none, which is the safe direction
+        """
+        if self.resource is None or self.resource == "*":
+            return True
+
+        return self.resource == resource
+
+    def __str__(self) -> str:
+        return self.action if self.resource is None else f"{self.action}:{self.resource}"
+
+
+class Decision(Enum):
+    """
+    What an :class:`Authorizer` answers.
+
+    ABSTAIN is what lets independent policies compose: the combining rule is fixed, any
+    DENY denies, otherwise any PERMIT permits, otherwise the request is denied.
+    """
+
+    PERMIT = "permit"
+    DENY = "deny"
+    ABSTAIN = "abstain"
+
+
+# ------------------------------------------------------------------------------
+
+
+@Specification(SERVICE_AUTHENTICATOR)
+class Authenticator(Protocol):
+    """
+    Specification of a credential store.
+
+    Authenticators are consulted in ``service.ranking`` order and the contract has three
+    states, not two: without the third one, a lower-ranked store becomes an oracle for
+    credentials a higher-ranked store already rejected.
+    """
+
+    def authenticate(self, credentials: Credentials) -> Subject | None:
+        """
+        Validates the given credentials.
+
+        :param credentials: What a transport extracted
+        :return: A Subject on success, None to abstain (not my kind, not my user)
+        :raise AuthenticationFailed: The credentials were presented and are wrong. No
+                                     lower-ranked store is consulted
+        """
+        ...
+
+
+@Specification(SERVICE_MEMBERSHIP_PROVIDER)
+class MembershipProvider(Protocol):
+    """
+    Specification of a provider of the groups and roles of a subject.
+
+    Every registered provider is consulted in both passes and the results are unioned. A
+    provider may answer only one of the two, returning an empty iterable for the other.
+    """
+
+    def get_groups(self, subject: Subject) -> Iterable[str]:
+        """
+        Returns the groups of the given subject.
+
+        This runs on every provider before :meth:`get_roles` runs on any, so
+        ``subject.roles`` is empty here by construction and must not be looked at.
+
+        :param subject: The subject being authenticated
+        :return: The group names this provider asserts, verbatim
+        """
+        ...
+
+    def get_roles(self, subject: Subject) -> Iterable[str]:
+        """
+        Returns the roles of the given subject.
+
+        The subject received here has its ``groups`` already complete, which is what
+        lets a policy grant a role from a group another provider contributed.
+
+        :param subject: The subject being authenticated, with its groups resolved
+        :return: The role names this provider grants, verbatim
+        """
+        ...
+
+
+@Specification(SERVICE_AUTHORIZER)
+class Authorizer(Protocol):
+    """
+    Specification of a policy.
+
+    The combining rule over the registered authorizers is fixed and not configurable.
+    """
+
+    def is_permitted(self, subject: Subject, permission: Permission) -> Decision:
+        """
+        Decides whether the given subject holds the given permission.
+
+        :param subject: The subject to check
+        :param permission: The requested permission
+        :return: PERMIT, DENY, or ABSTAIN to let another policy decide
+        """
+        ...
+
+
+@Specification(SERVICE_AUTHORIZATION)
+class Authorization(Protocol):
+    """
+    The authorization facade: the one service application code injects, or reaches
+    through :func:`use_authorization`.
+
+    ``subject=None`` everywhere means the current subject.
+    """
+
+    def is_permitted(self, permission: Permission, subject: Subject | None = None) -> bool:
+        """
+        Tells whether a subject holds a permission.
+
+        :param permission: The requested permission
+        :param subject: The subject to check, or None for the current one
+        :return: True if the permission is granted
+        """
+        ...
+
+    def check_permitted(self, permission: Permission, subject: Subject | None = None) -> None:
+        """
+        Checks that a subject holds a permission.
+
+        :param permission: The requested permission
+        :param subject: The subject to check, or None for the current one
+        :raise AccessDenied: The permission is not granted
+        """
+        ...
+
+    def has_role(self, role: str, subject: Subject | None = None) -> bool:
+        """
+        Tells whether a subject holds a role. The name is compared exactly.
+
+        :param role: The role to look for
+        :param subject: The subject to check, or None for the current one
+        :return: True if the subject holds the role
+        """
+        ...
+
+    def in_group(self, group: str, subject: Subject | None = None) -> bool:
+        """
+        Tells whether a subject belongs to a group. The name is compared exactly.
+
+        :param group: The group to look for
+        :param subject: The subject to check, or None for the current one
+        :return: True if the subject belongs to the group
+        """
+        ...
+
+
+# ------------------------------------------------------------------------------
+
+_SUBJECT: contextvars.ContextVar[Subject] = contextvars.ContextVar("pelix.security.subject")
+""" The current subject. Read through get_current_subject(), written through run_as() """
+
+
+def get_current_subject() -> Subject:
+    """
+    Returns the subject of the current execution path.
+
+    The current subject follows the standard Python context: wherever a context
+    propagates, the subject propagates, and code crossing a boundary a context does not
+    cross copies the context explicitly.
+
+    :return: The current subject, or ANONYMOUS when nothing was published
+    """
+    return _SUBJECT.get(ANONYMOUS)
+
+
+@contextlib.contextmanager
+def run_as(subject: Subject) -> Generator[None, None, None]:
+    """
+    Runs the body of the ``with`` block as the given subject.
+
+    This is privilege escalation by construction: in a framework with no sandbox,
+    anyone who can import it can elevate. It is a readability tool, not a security
+    boundary.
+
+    :param subject: The subject to publish
+    """
+    token = _SUBJECT.set(subject)
+    try:
+        yield
+    finally:
+        _SUBJECT.reset(token)
+
+
+@contextlib.contextmanager
+def use_authorization(bundle_context: "BundleContext") -> Generator[Authorization, None, None]:
+    """
+    Utility context to use the authorization service safely in a "with" block.
+    It looks after the authorization service and releases its reference when exiting
+    the context.
+
+    :param bundle_context: The calling bundle context
+    :return: The authorization service
+    :raise BundleException: Service not found
+    """
+    reference = bundle_context.get_service_reference(Authorization)
+    if reference is None:
+        raise BundleException("No authorization service available")
+
+    try:
+        yield bundle_context.get_service(reference)
+    finally:
+        try:
+            bundle_context.unget_service(reference)
+        except BundleException:
+            # Service might have already been unregistered
+            pass

--- a/pelix/security/_crypt.py
+++ b/pelix/security/_crypt.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Verification of the password hashes an Apache ``.htpasswd`` file can hold.
+
+Pure Python over :mod:`hashlib`, with no external dependency: ``{SHA}``, ``$apr1$``
+(Apache MD5) and ``$5$`` / ``$6$`` (SHA-crypt) are implemented here. bcrypt is used
+when the optional ``bcrypt`` distribution is installed and refused with a remediation
+otherwise, since a pure-Python Blowfish would be both hand-rolled cryptography and
+tens of times too slow.
+
+This is the one module of iPOPO where a wrong line silently accepts a wrong password,
+so it is written against the published algorithms, tested against published vectors,
+and deliberately free of cleverness.
+
+Private module: its contents are an implementation detail of
+:mod:`pelix.security.htpasswd`.
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+:version: 3.2.2
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import base64
+import hashlib
+import hmac
+import re
+from enum import Enum
+
+try:
+    import bcrypt
+except ImportError:
+    bcrypt = None  # type: ignore
+
+# Module version
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+# ------------------------------------------------------------------------------
+
+
+class Scheme(Enum):
+    """
+    Names the format of a stored ``.htpasswd`` hash.
+    """
+
+    SHA1 = "sha1"
+    """ {SHA}: unsalted and unstretched base64 SHA-1, as htpasswd -s produces """
+
+    APR1 = "apr1"
+    """ $apr1$: the Apache MD5 construction, as htpasswd -m produces """
+
+    SHA256 = "sha256crypt"
+    """ $5$: SHA-crypt over SHA-256, as htpasswd -2 produces """
+
+    SHA512 = "sha512crypt"
+    """ $6$: SHA-crypt over SHA-512, as htpasswd -5 produces """
+
+    BCRYPT = "bcrypt"
+    """ $2a$, $2b$, $2y$: bcrypt, which needs the optional bcrypt distribution """
+
+    PLAINTEXT = "plaintext"
+    """ Anything unrecognized, which is indistinguishable from a plaintext password """
+
+
+WEAK_SCHEMES = frozenset({Scheme.SHA1, Scheme.APR1, Scheme.PLAINTEXT})
+""" Schemes worth a warning when a file uses them """
+
+MAX_ROUNDS = 100000
+"""
+Highest accepted SHA-crypt rounds parameter.
+
+The format allows up to 999999999, which a password file can turn into a self-inflicted
+denial of service: one login would burn minutes of CPU.
+"""
+
+# Alphabet of the crypt base64 variant, in its own order: neither RFC 4648 nor the
+# Apache one uses this
+_ITOA64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+# Matches the classic DES crypt output: 13 characters of the crypt alphabet
+_DES_CRYPT = re.compile(rf"^[{re.escape(_ITOA64)}]{{13}}$")
+
+# Matches the optional "rounds=" parameter of a SHA-crypt salt
+_ROUNDS = re.compile(r"^rounds=(\d+)$")
+
+# SHA-crypt parameters, per digest
+_SHA_CRYPT = {
+    Scheme.SHA256: (hashlib.sha256, 32),
+    Scheme.SHA512: (hashlib.sha512, 64),
+}
+
+# Order in which the digest bytes are read back when encoding a SHA-crypt result. The
+# permutation is part of the format and differs between the two digests
+_SHA256_ORDER = (
+    (0, 10, 20),
+    (21, 1, 11),
+    (12, 22, 2),
+    (3, 13, 23),
+    (24, 4, 14),
+    (15, 25, 5),
+    (6, 16, 26),
+    (27, 7, 17),
+    (18, 28, 8),
+    (9, 19, 29),
+    (None, 31, 30),
+)
+
+_SHA512_ORDER = (
+    (0, 21, 42),
+    (22, 43, 1),
+    (44, 2, 23),
+    (3, 24, 45),
+    (25, 46, 4),
+    (47, 5, 26),
+    (6, 27, 48),
+    (28, 49, 7),
+    (50, 8, 29),
+    (9, 30, 51),
+    (31, 52, 10),
+    (53, 11, 32),
+    (12, 33, 54),
+    (34, 55, 13),
+    (56, 14, 35),
+    (15, 36, 57),
+    (37, 58, 16),
+    (59, 17, 38),
+    (18, 39, 60),
+    (40, 61, 19),
+    (62, 20, 41),
+    (None, None, 63),
+)
+
+# ------------------------------------------------------------------------------
+
+
+class UnsupportedHash(ValueError):
+    """
+    The stored hash uses a format this build cannot verify.
+
+    The message names the remediation, because that is what the operator needs.
+    """
+
+
+# ------------------------------------------------------------------------------
+
+
+def classify(stored: str) -> Scheme:
+    """
+    Names the scheme of a stored hash.
+
+    :param stored: The hash as it appears in the file
+    :return: The scheme of the hash, as a :class:`Scheme` member
+    :raise UnsupportedHash: The format is recognized and cannot be verified
+    """
+    if stored.startswith("{SHA}"):
+        return Scheme.SHA1
+
+    if stored.startswith("$apr1$"):
+        if not _has_md5():
+            raise UnsupportedHash(
+                "this Python build cannot compute MD5, so $apr1$ hashes cannot be verified. "
+                "Re-hash the file with: htpasswd -5"
+            )
+
+        return Scheme.APR1
+
+    if stored.startswith("$5$"):
+        return Scheme.SHA256
+
+    if stored.startswith("$6$"):
+        return Scheme.SHA512
+
+    if stored.startswith(("$2a$", "$2b$", "$2y$")):
+        if bcrypt is None:
+            raise UnsupportedHash(
+                "bcrypt hashes need the optional bcrypt distribution. Install it with: "
+                "pip install iPOPO[bcrypt], or re-hash the file with: htpasswd -5"
+            )
+
+        return Scheme.BCRYPT
+
+    if _DES_CRYPT.match(stored):
+        raise UnsupportedHash(
+            "DES crypt truncates the password to 8 characters and cannot be verified on "
+            "a modern Python. Re-hash the file with: htpasswd -5"
+        )
+
+    # Unknown formats are indistinguishable from plaintext: the caller decides what to do with it
+    return Scheme.PLAINTEXT
+
+
+def verify(password: str, stored: str) -> bool:
+    """
+    Tells whether the given password produces the given stored hash.
+
+    :param password: The candidate password, untouched: the stored hash was computed
+                     over exact bytes
+    :param stored: The hash as it appears in the file
+    :return: True if the password matches
+    :raise UnsupportedHash: The format cannot be verified by this build
+    """
+    scheme = classify(stored)
+
+    match scheme:
+        case Scheme.BCRYPT:
+            if bcrypt is None:
+                # classify() already refuses this scheme when the module is absent, so this
+                # is unreachable through it. It is also what says the attribute below exists
+                raise UnsupportedHash("bcrypt is not installed")
+
+            return bcrypt.checkpw(password.encode("utf-8"), stored.encode("utf-8"))
+
+        case Scheme.PLAINTEXT:
+            return hmac.compare_digest(password, stored)
+
+        case Scheme.SHA1:
+            digest = base64.b64encode(hashlib.sha1(password.encode("utf-8")).digest()).decode("ascii")
+            return hmac.compare_digest(f"{{SHA}}{digest}", stored)
+
+        case Scheme.APR1:
+            salt = stored[len("$apr1$") :].split("$", 1)[0]
+            return hmac.compare_digest(apr1(password, salt), stored)
+
+        case _:  # Scheme.SHA256 or Scheme.SHA512
+            return hmac.compare_digest(sha_crypt(password, stored, scheme), stored)
+
+
+def dummy_hash(scheme: Scheme) -> str:
+    """
+    Returns a hash of the given scheme, over a password nobody knows.
+
+    It exists so that an unknown user costs the same time as a known one: without it,
+    an unknown user returns instantly while a known one burns thousands of rounds, and
+    the difference enumerates the file.
+
+    :param scheme: The scheme of the dummy hash to return
+    :return: A stored hash of that scheme
+    """
+    return _DUMMY_HASHES[scheme]
+
+
+# ------------------------------------------------------------------------------
+
+
+def _has_md5() -> bool:
+    """
+    Tells whether this Python build can compute MD5.
+
+    A FIPS-restricted build raises ValueError. Passing ``usedforsecurity=False`` would
+    make ``$apr1$`` work, but it would be a lie: it *is* being used for security.
+
+    :return: True if hashlib.md5 is usable
+    """
+    try:
+        hashlib.md5(b"")
+    except ValueError:
+        return False
+
+    return True
+
+
+def _to64(value: int, length: int) -> str:
+    """
+    Encodes an integer in the crypt base64 alphabet, least significant group first.
+
+    :param value: The value to encode
+    :param length: Number of characters to emit
+    :return: The encoded characters
+    """
+    out = []
+    for _ in range(length):
+        out.append(_ITOA64[value & 0x3F])
+        value >>= 6
+
+    return "".join(out)
+
+
+def apr1(password: str, salt: str) -> str:
+    """
+    Computes the Apache MD5 hash of a password.
+
+    :param password: The candidate password
+    :param salt: The salt read from the stored hash, at most 8 characters
+    :return: The complete stored form, ``$apr1$salt$hash``
+    :raise UnsupportedHash: This Python build cannot compute MD5
+    """
+    if not _has_md5():
+        raise UnsupportedHash("this Python build cannot compute MD5")
+
+    raw_password = password.encode("utf-8")
+    raw_salt = salt[:8].encode("utf-8")
+
+    context = hashlib.md5(raw_password + b"$apr1$" + raw_salt)
+
+    # The password is folded in a second time, through a digest of its own
+    alternate = hashlib.md5(raw_password + raw_salt + raw_password).digest()
+    for offset in range(0, len(raw_password), 16):
+        context.update(alternate[: min(len(raw_password) - offset, 16)])
+
+    # Then one byte per bit of the password length, which is what makes an empty
+    # password differ from a one-character one
+    length = len(raw_password)
+    while length:
+        context.update(b"\0" if length & 1 else raw_password[:1])
+        length >>= 1
+
+    digest = context.digest()
+
+    # 1000 fixed rounds: not a work factor, just what the format says
+    for index in range(1000):
+        round_context = hashlib.md5()
+        round_context.update(raw_password if index & 1 else digest)
+        if index % 3:
+            round_context.update(raw_salt)
+
+        if index % 7:
+            round_context.update(raw_password)
+
+        round_context.update(digest if index & 1 else raw_password)
+        digest = round_context.digest()
+
+    encoded = "".join(
+        _to64((digest[first] << 16) | (digest[second] << 8) | digest[third], 4)
+        for first, second, third in ((0, 6, 12), (1, 7, 13), (2, 8, 14), (3, 9, 15), (4, 10, 5))
+    )
+    encoded += _to64(digest[11], 2)
+
+    return f"$apr1${salt}${encoded}"
+
+
+def sha_crypt(password: str, stored: str, scheme: Scheme) -> str:
+    """
+    Computes the SHA-crypt hash of a password, with the parameters of a stored hash.
+
+    ``$6$`` is not a SHA-512 of the salted password: it is a fixed multi-step digest
+    procedure which uses SHA-512 as its primitive, repeated ``rounds`` times.
+
+    :param password: The candidate password
+    :param stored: The stored hash, which carries the rounds and the salt
+    :param scheme: Scheme.SHA256 or Scheme.SHA512
+    :return: The complete stored form
+    :raise UnsupportedHash: The rounds parameter is above MAX_ROUNDS
+    """
+    digest_factory, size = _SHA_CRYPT[scheme]
+    prefix = "$5$" if scheme == Scheme.SHA256 else "$6$"
+
+    fields = stored[len(prefix) :].split("$")
+    rounds = 5000
+    explicit_rounds = False
+    match = _ROUNDS.match(fields[0]) if fields else None
+    if match is not None:
+        rounds = int(match.group(1))
+        explicit_rounds = True
+        fields = fields[1:]
+
+        if rounds > MAX_ROUNDS:
+            raise UnsupportedHash(
+                f"rounds={rounds} is above the accepted maximum of {MAX_ROUNDS}: verifying "
+                "this hash would take long enough to be a denial of service"
+            )
+
+        # The format clamps rather than refuses on the low side
+        rounds = max(rounds, 1000)
+
+    salt = fields[0][:16] if fields else ""
+
+    raw_password = password.encode("utf-8")
+    raw_salt = salt.encode("utf-8")
+
+    # Digest B, folded back into A a byte at a time below
+    alternate = digest_factory(raw_password + raw_salt + raw_password).digest()
+
+    context = digest_factory(raw_password + raw_salt)
+    for offset in range(0, len(raw_password), size):
+        context.update(alternate[: min(len(raw_password) - offset, size)])
+
+    length = len(raw_password)
+    while length:
+        context.update(alternate if length & 1 else raw_password)
+        length >>= 1
+
+    result = context.digest()
+
+    # Sequences P and S: the password and the salt, stretched to their own lengths
+    digest_p = digest_factory(raw_password * len(raw_password)).digest()
+    sequence_p = (digest_p * (len(raw_password) // size + 1))[: len(raw_password)]
+
+    digest_s = digest_factory(raw_salt * (16 + result[0])).digest()
+    sequence_s = (digest_s * (len(raw_salt) // size + 1))[: len(raw_salt)]
+
+    for index in range(rounds):
+        round_context = digest_factory()
+        round_context.update(sequence_p if index & 1 else result)
+        if index % 3:
+            round_context.update(sequence_s)
+
+        if index % 7:
+            round_context.update(sequence_p)
+
+        round_context.update(result if index & 1 else sequence_p)
+        result = round_context.digest()
+
+    order = _SHA256_ORDER if scheme == Scheme.SHA256 else _SHA512_ORDER
+    encoded = ""
+    for group in order:
+        value = 0
+        for index in group:
+            value = (value << 8) | (0 if index is None else result[index])
+
+        # The last group of each variant is shorter than the others
+        encoded += _to64(value, 4 if group[0] is not None else (3 if group[1] is not None else 2))
+
+    salt_field = f"rounds={rounds}${salt}" if explicit_rounds else salt
+    return f"{prefix}{salt_field}${encoded}"
+
+
+DUMMY_PASSWORD = "there-is-no-such-password"
+""" What the dummy hashes below were computed over. The result of verifying against
+them is discarded: only the time it takes matters """
+
+# Pinned rather than computed at import time, which would cost the very rounds they
+# exist to spend later. The tests check them against the implementation
+_DUMMY_HASHES = {
+    Scheme.SHA1: "{SHA}cJ3b4B91Y10bXRRAWZLfiUj7tUs=",
+    Scheme.APR1: "$apr1$pelix...$EqyZSGnwOp7/mTuHi654S.",
+    Scheme.SHA256: "$5$pelix.dummy.slt$ye.Yum4U0t3z5qnz02XrzljePTlTjo9LL2u.WzGU3b0",
+    Scheme.SHA512: (
+        "$6$pelix.dummy.slt$S9lAfcRXPoHQbLdUgwYNpDArV1FgJod7qEWBxsh."
+        "PFOLAerLPbAADn/C2Nz5O9JKPKM3ds5QueJ.a1.mpz1y90"
+    ),
+    Scheme.PLAINTEXT: DUMMY_PASSWORD,
+}

--- a/pelix/security/core.py
+++ b/pelix/security/core.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+The core of the security layer: the identity pipeline and the authorization facade.
+
+This bundle owns two things. :func:`authenticate` turns credentials into a
+:class:`~pelix.security.Subject` by sequencing the registered
+:class:`~pelix.security.Authenticator` and
+:class:`~pelix.security.MembershipProvider` services; it is transport-neutral, so an
+HTTP filter, a shell login and an MQTT ``CONNECT`` handler all call the same one. The
+:class:`~pelix.security.Authorization` facade combines the registered
+:class:`~pelix.security.Authorizer` services under a fixed rule, and is what
+``@AllowPermission`` and application code use.
+
+One rule runs through both: **an exception never grants**. An authorizer which raises
+denies, and a provider which raises stops the authentication rather than returning a
+subject whose roles are quietly incomplete.
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+:version: 3.2.2
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import contextlib
+import logging
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any
+
+from pelix.constants import ActivatorProto, BundleActivator, BundleException
+from pelix.ldapfilter import escape_LDAP
+from pelix.security import (
+    PROP_CREDENTIAL_KINDS,
+    AccessDenied,
+    AuthenticationFailed,
+    Authenticator,
+    Authorization,
+    Authorizer,
+    Credentials,
+    Decision,
+    MembershipProvider,
+    Permission,
+    Subject,
+    get_current_subject,
+)
+from pelix.security.decorators import set_authorization
+
+if TYPE_CHECKING:
+    from pelix.framework import BundleContext
+    from pelix.internals.registry import ServiceReference, ServiceRegistration
+
+# Module version
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+_logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------------------
+
+# The context of this bundle, which is how the module-level authenticate() reaches the
+# service registry: one writer, the activator below
+_context: "BundleContext | None" = None
+
+# Credential kinds already reported as having no authenticator, so that a
+# misconfiguration costs one warning rather than one per request
+_warned_kinds: set[str] = set()
+
+# Set once the absence of any authorizer has been reported
+_warned_no_authorizer = False
+
+# ------------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _use_services(specification: Any, ldap_filter: str | None = None) -> Generator[list[Any], None, None]:
+    """
+    Looks up every service of a specification, in descending ``service.ranking`` order,
+    and releases them when the block ends.
+
+    The registry is queried rather than the services injected, because an aggregate
+    injection only orders its *initial* content: a service registered later is appended,
+    and the authenticator contract depends on the ranking at every call. The same query
+    also applies the credential-kind filter, which an injection could not.
+
+    :param specification: The specification to look for
+    :param ldap_filter: An optional filter over the service properties
+    :return: The matching services, best-ranked first
+    """
+    context = _context
+    if context is None:
+        yield []
+        return
+
+    # Sorted explicitly: a filtered lookup is rebuilt from a set and loses the registry's ranking order
+    references: list[ServiceReference[Any]] = sorted(
+        context.get_all_service_references(specification, ldap_filter) or []
+    )
+    taken: list[ServiceReference[Any]] = []
+    try:
+        services = []
+        for reference in references:
+            services.append(context.get_service(reference))
+            taken.append(reference)
+
+        yield services
+    finally:
+        for reference in taken:
+            with contextlib.suppress(BundleException):
+                context.unget_service(reference)
+
+
+def _warn_about_missing_authenticator(kind: str) -> None:
+    """
+    Reports that no authenticator accepts a kind of credentials.
+
+    Declaring the accepted kinds is mandatory, so the most likely cause is an
+    authenticator which forgot the property rather than one which is genuinely absent.
+    Saying which of the two it is costs one extra query, in the failing case only.
+
+    :param kind: The kind of credentials which found no authenticator
+    """
+    if kind in _warned_kinds:
+        return
+
+    _warned_kinds.add(kind)
+
+    context = _context
+    others = (context.get_all_service_references(Authenticator, None) or []) if context is not None else []
+    if others:
+        _logger.warning(
+            "No Authenticator accepts credentials of kind '%s', although %d are registered. "
+            "An Authenticator must declare the kinds it accepts in its '%s' property",
+            kind,
+            len(others),
+            PROP_CREDENTIAL_KINDS,
+        )
+    else:
+        _logger.warning("No Authenticator is registered: refusing to authenticate '%s' credentials", kind)
+
+
+def authenticate(credentials: Credentials) -> Subject:
+    """
+    Turns credentials into a subject, with its groups and roles resolved.
+
+    The pipeline, which is the same whatever the transport was:
+
+    1. every :class:`~pelix.security.Authenticator` accepting this kind of credentials
+       is consulted in ranking order, under the three-state contract: a subject stops
+       the loop, None abstains, and ``AuthenticationFailed`` stops it without letting a
+       lower-ranked store answer;
+    2. every :class:`~pelix.security.MembershipProvider` contributes groups, and the
+       results are unioned;
+    3. the subject is rebuilt with those groups, and only then does every provider
+       contribute roles. The two passes are what lets a policy grant a role from a group
+       a *different* provider asserted: with a single pass that rule would silently
+       never fire;
+    4. the final subject is returned, authenticated, with ``method`` left unset.
+
+    ``method`` names the mechanism, which is exactly what a transport-neutral pipeline
+    cannot know: the caller stamps it with ``dataclasses.replace``.
+
+    :param credentials: What a transport extracted
+    :return: The authenticated subject
+    :raise AuthenticationFailed: The credentials are wrong, or no authenticator
+                                 accepted them
+    """
+    kind = credentials.KIND
+    ldap_filter = f"({PROP_CREDENTIAL_KINDS}={escape_LDAP(kind)})"
+
+    with _use_services(Authenticator, ldap_filter) as authenticators:
+        if not authenticators:
+            # Not ANONYMOUS: a caller which presented credentials and got back an
+            # unauthenticated subject cannot tell that apart from a wrong password
+            _warn_about_missing_authenticator(kind)
+            raise AuthenticationFailed(f"No Authenticator accepts '{kind}' credentials")
+
+        subject: Subject | None = None
+        for authenticator in authenticators:
+            candidate = authenticator.authenticate(credentials)
+            if candidate is not None:
+                subject = candidate
+                break
+
+    if subject is None:
+        raise AuthenticationFailed("No Authenticator recognized these credentials")
+
+    with _use_services(MembershipProvider) as providers:
+        groups = set(subject.groups)
+        for provider in providers:
+            groups.update(provider.get_groups(subject))
+
+        # Rebuilt before the second pass, or a role granted from a group contributed by
+        # another provider would never be seen
+        enriched = Subject(subject.name, frozenset(groups), attributes=subject.attributes)
+
+        roles = set(subject.roles)
+        for provider in providers:
+            roles.update(provider.get_roles(enriched))
+
+    # The pipeline owns the final bean: an authenticator which forgets authenticated=True
+    # cannot produce a subject which passes nothing
+    return Subject(
+        subject.name,
+        frozenset(groups),
+        frozenset(roles),
+        subject.attributes,
+        authenticated=True,
+    )
+
+
+# ------------------------------------------------------------------------------
+
+
+class _AuthorizationImpl(Authorization):
+    """
+    Combines the registered authorizers under one fixed rule: any DENY denies,
+    otherwise any PERMIT permits, otherwise the request is denied.
+
+    The rule is deliberately not configurable. Someone will ask for permit-overrides,
+    and the answer is to write one authorizer: a pluggable combining algorithm is how a
+    small authorization layer turns into XACML.
+    """
+
+    def is_permitted(self, permission: Permission, subject: Subject | None = None) -> bool:
+        if subject is None:
+            subject = get_current_subject()
+
+        with _use_services(Authorizer) as authorizers:
+            if not authorizers:
+                self.__warn_about_missing_authorizer()
+                return False
+
+            permitted = False
+            for authorizer in authorizers:
+                try:
+                    decision = authorizer.is_permitted(subject, permission)
+                except Exception:
+                    # An authorizer which cannot decide has not decided, and continuing
+                    # would let a broken policy open a door
+                    _logger.exception("Error asking %s about %s: denying", authorizer, permission)
+                    return False
+
+                if decision is Decision.DENY:
+                    return False
+
+                if decision is Decision.PERMIT:
+                    permitted = True
+
+            return permitted
+
+    def check_permitted(self, permission: Permission, subject: Subject | None = None) -> None:
+        if not self.is_permitted(permission, subject):
+            raise AccessDenied(f"Not permitted: {permission}")
+
+    def has_role(self, role: str, subject: Subject | None = None) -> bool:
+        return role in (get_current_subject() if subject is None else subject).roles
+
+    def in_group(self, group: str, subject: Subject | None = None) -> bool:
+        return group in (get_current_subject() if subject is None else subject).groups
+
+    @staticmethod
+    def __warn_about_missing_authorizer() -> None:
+        """
+        Reports, once, that nothing can decide a permission.
+
+        Reported on the first denial rather than at startup, because at startup the
+        bundle providing the policy has usually not been started yet.
+        """
+        global _warned_no_authorizer
+        if not _warned_no_authorizer:
+            _warned_no_authorizer = True
+            _logger.warning(
+                "No Authorizer is registered: every permission is denied. Start a policy "
+                "bundle, or instantiate the allow-all authorizer if that is really wanted"
+            )
+
+
+# ------------------------------------------------------------------------------
+
+
+@BundleActivator
+class Activator(ActivatorProto):
+    """
+    Publishes the authorization service and the bundle context the pipeline uses
+    """
+
+    def __init__(self) -> None:
+        self.__registration: ServiceRegistration[Authorization] | None = None
+
+    def start(self, context: "BundleContext") -> None:
+        """
+        Bundle started: publish the facade and fill the single decorator slot
+        """
+        global _context
+        _context = context
+
+        authorization = _AuthorizationImpl()
+        self.__registration = context.register_service(Authorization, authorization, {})
+        set_authorization(authorization)
+
+    def stop(self, context: "BundleContext") -> None:
+        """
+        Bundle stopped: from here on, @AllowPermission denies
+        """
+        global _context
+
+        set_authorization(None)
+        if self.__registration is not None:
+            self.__registration.unregister()
+            self.__registration = None
+
+        _context = None

--- a/pelix/security/decorators.py
+++ b/pelix/security/decorators.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Declarative security decorators.
+
+Read every one of them as "allow only": ``@AllowGroup("dev")`` means "allow only the
+dev group". Each decorator narrows who can reach the target, and the names listed
+inside one decorator are alternatives. The rule follows from that reading: any-of
+within one decorator, all-of when they are stacked, and a method-level declaration
+replaces a class-level one entirely.
+
+They work on plain classes, with no iPOPO and, for all but ``@AllowPermission``, with
+no bundle started at all: they read or write the current subject and nothing else.
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+:version: 3.2.2
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import functools
+import inspect
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from pelix.security import (
+    AccessDenied,
+    AuthenticationRequired,
+    Authorization,
+    Permission,
+    Subject,
+    get_current_subject,
+    run_as,
+)
+
+# Module version
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+_logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------------------
+
+SECURITY_ATTRIBUTE = "__pelix_security__"
+""" Attribute holding the security declarations of a decorated callable """
+
+# The one global. Only @AllowPermission needs a service, and this is the single slot
+# holding it: one writer, the activator of the pelix.security.core bundle
+_authorization: Authorization | None = None
+
+# Permissions already reported as undecidable, so that a stopped bundle costs one
+# warning per distinct permission rather than one per call
+_warned_permissions: set[str] = set()
+
+# ------------------------------------------------------------------------------
+
+
+def set_authorization(service: Authorization | None) -> None:
+    """
+    Publishes the authorization service used by ``@AllowPermission``.
+
+    There is exactly one writer, the activator of the ``pelix.security.core`` bundle,
+    which sets it on start and clears it on stop.
+
+    :param service: The authorization service, or None to clear the slot
+    """
+    global _authorization
+    _authorization = service
+
+
+def _refuse(subject: Subject, reason: str) -> None:
+    """
+    Raises the refusal which fits the subject.
+
+    The choice is mechanical: an unauthenticated caller can still be helped by a
+    challenge, an authenticated one cannot, and a transport maps the two exceptions to
+    401 and 403.
+
+    :param subject: The subject which was refused
+    :param reason: Why it was refused
+    :raise AuthenticationRequired: The subject is not authenticated
+    :raise AccessDenied: The subject is authenticated and still not allowed
+    """
+    if not subject.authenticated:
+        raise AuthenticationRequired(reason)
+
+    raise AccessDenied(reason)
+
+
+class _Declaration:
+    """
+    One application of a decorator: what it checks, and what the shell must be able to
+    print without invoking anything
+    """
+
+    __slots__ = ("check", "kind", "subject", "values")
+
+    def __init__(
+        self,
+        kind: str,
+        values: tuple[Any, ...] = (),
+        check: Callable[[Subject], None] | None = None,
+        subject: Subject | None = None,
+    ) -> None:
+        """
+        :param kind: Name of the decorator which produced this declaration
+        :param values: The names it was given
+        :param check: What to run against the current subject before the call
+        :param subject: The identity to publish around the call, for @RunAs
+        """
+        self.kind = kind
+        self.values = values
+        self.check = check
+        self.subject = subject
+
+    def __repr__(self) -> str:
+        return f"{self.kind}{self.values}" if self.values else self.kind
+
+
+def _decorate(target: Any, declaration: _Declaration | None) -> Any:
+    """
+    Wraps and marks a target, or sets a class default.
+
+    Two flavours of wrapper are emitted, because a synchronous wrapper around a
+    coroutine function checks and restores the context before the body ever runs: that
+    turns ``@RunAs`` into a no-op which looks correct.
+
+    :param target: The class or callable being decorated
+    :param declaration: What was declared, or None for "no narrowing"
+    :return: The class, or a wrapper around the callable
+    """
+    if isinstance(target, type):
+        return _decorate_class(target, declaration)
+
+    existing: list[_Declaration] = list(getattr(target, SECURITY_ATTRIBUTE, ()))
+    if declaration is None:
+        # @AllowAll: nothing to wrap. The mark is what makes a class-level default skip
+        # this method
+        setattr(target, SECURITY_ATTRIBUTE, existing)
+        return target
+
+    subject = declaration.subject
+    check = declaration.check
+
+    if inspect.iscoroutinefunction(target):
+
+        @functools.wraps(target)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if subject is not None:
+                with run_as(subject):
+                    return await target(*args, **kwargs)
+
+            if check is not None:
+                check(get_current_subject())
+
+            return await target(*args, **kwargs)
+
+    else:
+
+        @functools.wraps(target)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:  # type: ignore[misc]
+            if subject is not None:
+                with run_as(subject):
+                    return target(*args, **kwargs)
+
+            if check is not None:
+                check(get_current_subject())
+
+            return target(*args, **kwargs)
+
+    # Built fresh: mutating in place would rewrite the wrapped function's own declaration too
+    setattr(wrapper, SECURITY_ATTRIBUTE, [*existing, declaration])
+    return wrapper
+
+
+def _decorate_class(clazz: type, declaration: _Declaration | None) -> type:
+    """
+    Sets a class default.
+
+    It applies to every function defined in that class body whose name does not start
+    with an underscore: without that rule, a class-level ``@DenyAll`` would also wrap
+    ``__init__`` and present as a construction error rather than an authorization one.
+
+    :param clazz: The decorated class
+    :param declaration: What was declared, or None for "no narrowing"
+    :return: The class itself
+    """
+    for name, member in list(vars(clazz).items()):
+        if name.startswith("_") or not inspect.isfunction(member):
+            # Not a public method defined in this body: inherited methods, nested
+            # classes, static and class methods are all left alone
+            continue
+
+        if hasattr(member, SECURITY_ATTRIBUTE):
+            # Method-level replaces class-level entirely. Method decorators run first,
+            # so this falls out of the order of evaluation rather than needing a merge
+            continue
+
+        setattr(clazz, name, _decorate(member, declaration))
+
+    return clazz
+
+
+def _reject_bare_use(decorator: str, first: Any, example: str) -> None:
+    """
+    Refuses an argument-taking decorator applied without its argument.
+
+    Written bare, the decorator would bind the decorated function as its first name and
+    fail much later with a confusing message. This is a callable check used to refuse an
+    unsupported form loudly, never to choose silently between two supported ones.
+
+    :param decorator: Name of the decorator, for the message
+    :param first: The value given as the first name
+    :param example: How to write it properly
+    :raise TypeError: The decorator was applied bare
+    """
+    if callable(first):
+        raise TypeError(f"@{decorator} takes at least one name: write {example}")
+
+
+# ------------------------------------------------------------------------------
+
+
+def AllowAuthenticated(target: Any) -> Any:
+    """
+    Allows only authenticated subjects. Written bare, without parentheses.
+    """
+
+    def check(subject: Subject) -> None:
+        if not subject.authenticated:
+            _refuse(subject, "Authentication required")
+
+    return _decorate(target, _Declaration("AllowAuthenticated", check=check))
+
+
+def AllowAll(target: Any) -> Any:
+    """
+    No narrowing. Written bare, without parentheses.
+
+    Its point is to override a class-level default: it marks the target, which is what
+    makes the class decorator skip it.
+    """
+    return _decorate(target, None)
+
+
+def DenyAll(target: Any) -> Any:
+    """
+    Total narrowing. Written bare, without parentheses.
+
+    It always raises :class:`~pelix.security.AccessDenied`, even for an anonymous
+    subject: no credential would help, so offering a challenge would be a lie.
+    """
+
+    def check(subject: Subject) -> None:
+        raise AccessDenied("Denied to everyone")
+
+    return _decorate(target, _Declaration("DenyAll", check=check))
+
+
+class AllowGroup:
+    """
+    Allows only members of the given groups. Any of them is enough.
+
+    Group names are compared exactly, as they are everywhere else in this layer.
+    """
+
+    __slots__ = ("_groups",)
+
+    def __init__(self, group: str, *more: str) -> None:
+        """
+        :param group: A group name, mandatory
+        :param more: Other acceptable group names
+        :raise TypeError: The decorator was applied without a group name
+        """
+        _reject_bare_use("AllowGroup", group, '@AllowGroup("dev")')
+        self._groups = (group, *more)
+
+    def __call__(self, target: Any) -> Any:
+        groups = self._groups
+
+        def check(subject: Subject) -> None:
+            if not subject.groups.intersection(groups):
+                _refuse(subject, f"Not a member of any of the groups {groups}")
+
+        return _decorate(target, _Declaration("AllowGroup", groups, check))
+
+
+class AllowRole:
+    """
+    Allows only holders of the given roles. Any of them is enough.
+
+    Role names are compared exactly.
+    """
+
+    __slots__ = ("_roles",)
+
+    def __init__(self, role: str, *more: str) -> None:
+        """
+        :param role: A role name, mandatory
+        :param more: Other acceptable role names
+        :raise TypeError: The decorator was applied without a role name
+        """
+        _reject_bare_use("AllowRole", role, '@AllowRole("admin")')
+        self._roles = (role, *more)
+
+    def __call__(self, target: Any) -> Any:
+        roles = self._roles
+
+        def check(subject: Subject) -> None:
+            if not subject.roles.intersection(roles):
+                _refuse(subject, f"Does not hold any of the roles {roles}")
+
+        return _decorate(target, _Declaration("AllowRole", roles, check))
+
+
+class AllowPermission:
+    """
+    Allows only holders of the given permission.
+
+    The specification is parsed once, at decoration time, and this is the only decorator
+    which needs a service: with the ``pelix.security.core`` bundle stopped it denies,
+    logging one warning per distinct permission. That is correct behaviour and it has to
+    be known in advance: installing a library whose methods carry this decorator, and
+    not starting the bundle, means those methods raise.
+    """
+
+    __slots__ = ("_permission",)
+
+    def __init__(self, permission: str) -> None:
+        """
+        :param permission: A permission specification, ``action`` or ``action:resource``
+        :raise ValueError: The specification has no action
+        """
+        self._permission = Permission.parse(permission)
+
+    def __call__(self, target: Any) -> Any:
+        permission = self._permission
+
+        def check(subject: Subject) -> None:
+            authorization = _authorization
+            if authorization is None:
+                # Fail closed, and warn once per permission rather than once per call
+                key = str(permission)
+                if key not in _warned_permissions:
+                    _warned_permissions.add(key)
+                    _logger.warning(
+                        "No authorization service: denying %s. Is the pelix.security.core bundle started?",
+                        key,
+                    )
+
+                raise AccessDenied(f"No authorization service to decide {permission}")
+
+            if not authorization.is_permitted(permission, subject):
+                _refuse(subject, f"Not permitted: {permission}")
+
+        return _decorate(target, _Declaration("AllowPermission", (str(permission),), check))
+
+
+class RunAs:
+    """
+    Runs the target under another identity.
+
+    This is privilege escalation by construction: in a framework with no sandbox,
+    anyone who can import it can elevate. It is a readability tool, not a security
+    boundary, and the absence of an all-powerful built-in subject keeps it at worst a
+    lateral move.
+    """
+
+    __slots__ = ("_subject",)
+
+    def __init__(self, subject: Subject) -> None:
+        """
+        :param subject: The identity to publish around every call
+        """
+        self._subject = subject
+
+    def __call__(self, target: Any) -> Any:
+        return _decorate(target, _Declaration("RunAs", (self._subject.name,), subject=self._subject))

--- a/pelix/security/htpasswd.py
+++ b/pelix/security/htpasswd.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Credential store over an Apache ``.htpasswd`` file, with the groups of a matching
+``.htgroup``.
+
+One component provides both halves: the password file and the group file are two
+properties of the same factory, so the simplest deployment adds one bundle rather than
+two.
+
+Both files are parsed as a whole when they are loaded, not entry by entry at login: an
+entry this build cannot verify is reported with its file and line number at deploy time
+and the user is left **absent**, rather than present and unverifiable. A load-time
+failure is found by the operator; a login-time failure is found by a user at three in
+the morning.
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+:version: 3.2.2
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import contextlib
+import logging
+import os
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from pelix import services
+from pelix.ipopo.decorators import ComponentFactory, Invalidate, Property, Provides, Validate
+from pelix.security import (
+    FACTORY_HTPASSWD,
+    PROP_CREDENTIAL_KINDS,
+    PROP_HTPASSWD_FILE,
+    PROP_HTPASSWD_GROUPS,
+    PROP_HTPASSWD_PLAINTEXT,
+    AuthenticationFailed,
+    Authenticator,
+    Credentials,
+    MembershipProvider,
+    Subject,
+    UsernamePassword,
+    _crypt,
+)
+
+if TYPE_CHECKING:
+    from pelix.framework import BundleContext
+
+# Module version
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+_logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------------------
+
+# Permission bits which must not be set on a password file: it is readable by somebody
+# other than its owner
+_SHARED_MODE_BITS = 0o077
+
+# ------------------------------------------------------------------------------
+
+
+def parse_htpasswd(
+    lines: Iterable[str], path: str, allow_plaintext: bool = False
+) -> tuple[dict[str, str], int]:
+    """
+    Parses the content of a ``.htpasswd`` file: ``user:hash`` per line, ``#`` comments.
+
+    A hash this build cannot verify is reported and its user left out, so that nothing
+    can be present and unverifiable at the same time.
+
+    :param lines: The lines of the file
+    :param path: Path of the file, for the messages
+    :param allow_plaintext: Accept an unrecognized hash as a plaintext password
+    :return: The users and their stored hash, and the number of skipped entries
+    """
+    users: dict[str, str] = {}
+    skipped = 0
+
+    for number, raw_line in enumerate(lines, start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        name, separator, stored = line.partition(":")
+        if not separator or not name or not stored:
+            _logger.warning("%s:%d: ignoring a line which is not 'user:hash'", path, number)
+            skipped += 1
+            continue
+
+        try:
+            scheme = _crypt.classify(stored)
+        except _crypt.UnsupportedHash as ex:
+            # Never the hash itself, only what it is and where it is
+            _logger.warning("%s:%d: ignoring user '%s': %s", path, number, name, ex)
+            skipped += 1
+            continue
+
+        if scheme == _crypt.Scheme.PLAINTEXT and not allow_plaintext:
+            _logger.warning(
+                "%s:%d: ignoring user '%s': unrecognized hash format. Set '%s' to true if this "
+                "really is a plaintext password",
+                path,
+                number,
+                name,
+                PROP_HTPASSWD_PLAINTEXT,
+            )
+            skipped += 1
+            continue
+
+        if scheme in _crypt.WEAK_SCHEMES:
+            _logger.warning(
+                "%s:%d: user '%s' uses the weak '%s' scheme: an offline copy of this file is "
+                "cracked quickly. Re-hash it with: htpasswd -5",
+                path,
+                number,
+                name,
+                scheme.value,
+            )
+
+        # User names are compared exactly, which is what Apache itself does with these
+        # files: nothing is transformed on the way in
+        users[name] = stored
+
+    return users, skipped
+
+
+def parse_htgroup(lines: Iterable[str], path: str) -> dict[str, set[str]]:
+    """
+    Parses the content of a ``.htgroup`` file: ``groupname: user1 user2`` per line,
+    ``#`` comments, and a user may appear in several lines.
+
+    There is no nesting, deliberately: refusing a membership graph is what keeps a
+    subject a flat immutable snapshot.
+
+    :param lines: The lines of the file
+    :param path: Path of the file, for the messages
+    :return: The groups of each user
+    """
+    groups_of: dict[str, set[str]] = {}
+
+    for number, raw_line in enumerate(lines, start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        group, separator, members = line.partition(":")
+        if not separator or not group:
+            _logger.warning("%s:%d: ignoring a line which is not 'group: users'", path, number)
+            continue
+
+        for member in members.split():
+            groups_of.setdefault(member, set()).add(group)
+
+    return groups_of
+
+
+def _read_lines(path: str) -> list[str] | None:
+    """
+    Reads a file, reporting rather than raising.
+
+    :param path: Path of the file
+    :return: Its lines, or None if it could not be read or is empty
+    """
+    try:
+        with open(path, encoding="utf-8") as file:
+            lines = file.readlines()
+    except OSError as ex:
+        _logger.error("Error reading %s: %s", path, ex)
+        return None
+
+    if not any(line.strip() for line in lines):
+        # Far more likely a partial write than an intentional revocation of everyone
+        _logger.error("%s is empty: keeping the previous content", path)
+        return None
+
+    return lines
+
+
+def _warn_about_file_mode(path: str) -> None:
+    """
+    Warns when a password file is readable by somebody other than its owner.
+
+    :param path: Path of the file
+    """
+    if os.name != "posix":
+        return
+
+    try:
+        mode = os.stat(path).st_mode
+    except OSError:
+        return
+
+    if mode & _SHARED_MODE_BITS:
+        _logger.warning("%s is readable by other users (mode %o): run chmod 600 on it", path, mode & 0o777)
+
+
+# ------------------------------------------------------------------------------
+
+
+@ComponentFactory(FACTORY_HTPASSWD)
+@Provides([Authenticator, MembershipProvider, services.FileInstallListener])
+@Property("_credential_kinds", PROP_CREDENTIAL_KINDS, ("password",))
+@Property("_users_path", PROP_HTPASSWD_FILE)
+@Property("_groups_path", PROP_HTPASSWD_GROUPS)
+@Property("_allow_plaintext", PROP_HTPASSWD_PLAINTEXT, False)
+@Property("_watched_folder", services.PROP_FILEINSTALL_FOLDER)
+class HtpasswdStore(Authenticator, MembershipProvider, services.FileInstallListener):
+    """
+    Authenticates against a ``.htpasswd`` file and reports the groups of a ``.htgroup``.
+
+    Both files are reloaded through the File Install service when it is available. When
+    it is not, they are read once at validation: that is graceful degradation, not a
+    failure, and it costs no polling thread of our own.
+    """
+
+    def __init__(self) -> None:
+        self._credential_kinds: tuple[str, ...] = ("password",)
+        self._users_path: str = ""
+        self._groups_path: str = ""
+        self._allow_plaintext: bool = False
+        self._watched_folder: str = ""
+
+        # user name -> stored hash
+        self._users: dict[str, str] = {}
+        # user name -> group names
+        self._groups_of: dict[str, set[str]] = {}
+        # Scheme of the hash an unknown user is checked against, so that it costs what a
+        # known one costs
+        self._dummy_scheme: _crypt.Scheme = _crypt.Scheme.SHA512
+
+    @Validate
+    def _validate(self, _: "BundleContext") -> None:
+        """
+        Component validated: read both files once
+        """
+        if not self._users_path:
+            raise ValueError(f"No password file: set the '{PROP_HTPASSWD_FILE}' property")
+
+        self._users_path = os.path.abspath(self._users_path)
+        if self._groups_path:
+            self._groups_path = os.path.abspath(self._groups_path)
+
+        self.reload()
+
+        # Published last: this is what File Install binds on, and it must not see the
+        # component before its content is loaded
+        self._watched_folder = os.path.dirname(self._users_path)
+
+    @Invalidate
+    def _invalidate(self, _: "BundleContext") -> None:
+        """
+        Component invalidated
+        """
+        self._watched_folder = ""
+        self._users = {}
+        self._groups_of = {}
+
+    def reload(self) -> None:
+        """
+        Reloads both files.
+
+        On a parse failure, an empty file or an unreadable one, the previous table is
+        **kept** and an error is logged. This is the one place where failing closed is
+        the wrong instinct: an empty file is far more likely a partial write than an
+        intentional revocation of everyone. A successfully parsed file with a user
+        removed does revoke that user.
+        """
+        lines = _read_lines(self._users_path)
+        if lines is not None:
+            _warn_about_file_mode(self._users_path)
+            users, skipped = parse_htpasswd(lines, self._users_path, self._allow_plaintext)
+            if users:
+                self._users = users
+                self._dummy_scheme = self.__pick_dummy_scheme(users)
+                _logger.info(
+                    "Loaded %d users from %s, skipped %d unsupported entries",
+                    len(users),
+                    self._users_path,
+                    skipped,
+                )
+            else:
+                _logger.error(
+                    "No usable entry in %s: keeping the previous %d users", self._users_path, len(self._users)
+                )
+
+        if self._groups_path:
+            group_lines = _read_lines(self._groups_path)
+            if group_lines is not None:
+                self._groups_of = parse_htgroup(group_lines, self._groups_path)
+                _logger.info("Loaded the groups of %d users from %s", len(self._groups_of), self._groups_path)
+
+    @staticmethod
+    def __pick_dummy_scheme(users: dict[str, str]) -> _crypt.Scheme:
+        """
+        Picks the scheme an unknown user is checked against: the most expensive one the
+        file actually uses, so that the fake check is not visibly cheaper than a real
+        one.
+
+        :param users: The loaded users
+        :return: The scheme, as a :class:`_crypt.Scheme` member
+        """
+        seen: set[_crypt.Scheme] = set()
+        for stored in users.values():
+            with contextlib.suppress(_crypt.UnsupportedHash):
+                seen.add(_crypt.classify(stored))
+
+        for scheme in (
+            _crypt.Scheme.SHA512,
+            _crypt.Scheme.SHA256,
+            _crypt.Scheme.APR1,
+            _crypt.Scheme.SHA1,
+        ):
+            if scheme in seen:
+                return scheme
+
+        return _crypt.Scheme.SHA512
+
+    # ------------------------------------------------------------------------
+
+    def authenticate(self, credentials: Credentials) -> Subject | None:
+        """
+        Validates a user name and a password against the loaded file
+        """
+        if not isinstance(credentials, UsernamePassword):
+            # Not our kind of credentials: abstain
+            return None
+
+        stored = self._users.get(credentials.username)
+        if stored is None:
+            # An unknown user must not answer instantly while a known one burns
+            # thousands of rounds: the difference alone enumerates the file
+            with contextlib.suppress(_crypt.UnsupportedHash):
+                _crypt.verify(credentials.password, _crypt.dummy_hash(self._dummy_scheme))
+
+            # Abstain rather than fail: this store has never heard of that name, and
+            # raising would stop the loop and make every lower-ranked store unreachable
+            return None
+
+        try:
+            valid = _crypt.verify(credentials.password, stored)
+        except _crypt.UnsupportedHash as ex:
+            # Unreachable through a loaded file, which refuses such an entry
+            _logger.error("Cannot verify the hash of '%s': %s", credentials.username, ex)
+            return None
+
+        if not valid:
+            # A store which knows the user and rejects the password stops the loop: that
+            # is what closes the credential oracle
+            raise AuthenticationFailed(f"Wrong password for '{credentials.username}'")
+
+        return Subject(credentials.username)
+
+    def get_groups(self, subject: Subject) -> Iterable[str]:
+        """
+        Returns the groups the ``.htgroup`` file gives to the subject
+        """
+        return frozenset(self._groups_of.get(subject.name, ()))
+
+    def get_roles(self, subject: Subject) -> Iterable[str]:
+        """
+        A password file holds no role: that is the policy's job
+        """
+        return ()
+
+    # ------------------------------------------------------------------------
+
+    def folder_change(
+        self, folder: str, added: Iterable[str], updated: Iterable[str], deleted: Iterable[str]
+    ) -> None:
+        """
+        The File Install service reports a change in the watched folder.
+
+        It delivers base names, and it watches a whole folder, so the two files of
+        interest have to be picked out of everything else living next to them.
+        """
+        watched = {os.path.basename(path) for path in (self._users_path, self._groups_path) if path}
+        changed = watched.intersection(set(added) | set(updated) | set(deleted))
+        if changed:
+            _logger.info("Reloading %s", ", ".join(sorted(changed)))
+            self.reload()

--- a/pelix/security/policy.py
+++ b/pelix/security/policy.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+The policy file: roles granted from users and groups, permissions granted to roles.
+
+One component provides both halves, so the two levels live in one readable file::
+
+    [roles.admin]
+    users  = ["thomas"]
+    groups = ["dev-leads"]
+
+    [roles.operator]
+    groups = ["dev", "ops"]
+
+    [permissions]
+    admin    = ["jobs.*", "config.*"]
+    operator = ["jobs.read", "jobs.submit"]
+
+Read it as: groups and users are facts asserted by the identity source, roles are
+granted from those facts, and permissions are granted to roles.
+
+The format is TOML for one decisive reason: **TOML keys are case-sensitive by
+specification**, and role names are keys here. An INI file would have folded ``Admin``
+into ``admin`` in the very component held up as the example of folding nothing, and the
+defence would have been one easily-lost configuration line. Typed tables also remove the
+``user:`` / ``group:`` prefixes an untyped value would have needed, and a duplicate key
+becomes a parse error instead of a silently kept last one.
+
+This module also ships the deliberate escape hatch: an allow-all authorizer, which
+warns loudly when it validates.
+
+:author: Thomas Calmant
+:copyright: Copyright 2026, Thomas Calmant
+:license: Apache License 2.0
+:version: 3.2.2
+
+..
+
+    Copyright 2026 Thomas Calmant
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import logging
+import os
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+from pelix import services
+from pelix.ipopo.decorators import ComponentFactory, Invalidate, Property, Provides, Validate
+from pelix.security import (
+    FACTORY_ALLOW_ALL,
+    FACTORY_POLICY_FILE,
+    PROP_POLICY_FILE,
+    Authorizer,
+    Decision,
+    MembershipProvider,
+    Permission,
+    Subject,
+)
+
+try:
+    # Only one of the two exists on any given interpreter, so a type checker aimed at
+    # the lowest supported version cannot resolve the first one
+    import tomllib  # ty: ignore[unresolved-import]
+except ImportError:  # Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef] # ty: ignore[unresolved-import]
+
+if TYPE_CHECKING:
+    from pelix.framework import BundleContext
+
+# Module version
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Documentation strings format
+__docformat__ = "restructuredtext en"
+
+_logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------------------
+
+
+class PolicyError(ValueError):
+    """
+    The file is well-formed TOML but not a well-shaped policy.
+
+    ``tomllib`` guarantees the former only: it will happily return
+    ``{"roles": {"admin": 12}}``.
+    """
+
+
+def _as_names(value: Any, where: str) -> frozenset[str]:
+    """
+    Reads a list of names, refusing anything else.
+
+    :param value: The value read from the file
+    :param where: Where it came from, for the message
+    :return: The names
+    :raise PolicyError: The value is not a list of strings
+    """
+    if not isinstance(value, list) or not all(isinstance(entry, str) for entry in value):
+        raise PolicyError(f"{where} must be a list of strings")
+
+    return frozenset(value)
+
+
+class PolicyTable:
+    """
+    A parsed policy: which roles a subject holds, and what each role may do.
+
+    Plain object, with no framework behind it, so a policy can be checked in a test
+    with one ``PolicyTable(text)``.
+    """
+
+    def __init__(self, text: str, source: str = "<memory>") -> None:
+        """
+        :param text: The content of the policy file
+        :param source: Where it came from, for the messages
+        :raise PolicyError: The file is not a well-shaped policy
+        :raise tomllib.TOMLDecodeError: The file is not well-formed TOML
+        """
+        self._source = source
+        self._role_users: dict[str, frozenset[str]] = {}
+        self._role_groups: dict[str, frozenset[str]] = {}
+        self._permissions: dict[str, list[Permission]] = {}
+
+        self.__load(tomllib.loads(text))
+        self.__report_dangling()
+
+    def __load(self, data: dict[str, Any]) -> None:
+        """
+        Validates the shape of the parsed document and fills the tables.
+
+        Anything unexpected refuses the file as a whole rather than silently dropping
+        the malformed half.
+
+        :param data: The parsed TOML document
+        :raise PolicyError: The document is not a well-shaped policy
+        """
+        roles = data.get("roles", {})
+        if not isinstance(roles, dict):
+            raise PolicyError("[roles] must be a table")
+
+        for role, grants in roles.items():
+            if not isinstance(grants, dict):
+                raise PolicyError(f"[roles.{role}] must be a table of users and groups")
+
+            unknown = set(grants) - {"users", "groups"}
+            if unknown:
+                raise PolicyError(f"[roles.{role}] has unknown keys: {sorted(unknown)}")
+
+            self._role_users[role] = _as_names(grants.get("users", []), f"[roles.{role}].users")
+            self._role_groups[role] = _as_names(grants.get("groups", []), f"[roles.{role}].groups")
+
+        permissions = data.get("permissions", {})
+        if not isinstance(permissions, dict):
+            raise PolicyError("[permissions] must be a table")
+
+        for role, specs in permissions.items():
+            names = _as_names(specs, f"[permissions].{role}")
+            for spec in sorted(names):
+                if "*" in spec:
+                    # A wildcard is one typo away from full access, so every one of them
+                    # is named when the file is loaded
+                    _logger.warning(
+                        "%s: role '%s' is granted the wildcard permission '%s'", self._source, role, spec
+                    )
+
+            self._permissions[role] = [Permission.parse(spec) for spec in sorted(names)]
+
+    def __report_dangling(self) -> None:
+        """
+        Reports a role granted to somebody but given no permission, and a permission
+        given to a role nobody holds.
+
+        Every name here is matched exactly against what an identity source provided, so
+        it has to be spelled the way that source spells it. Most spelling mistakes
+        produce one of those two shapes, which is what makes this cheap check worth its
+        lines: the typo surfaces at load rather than as an unexplained denial later.
+        """
+        granted = set(self._role_users) | set(self._role_groups)
+
+        for role in sorted(granted - set(self._permissions)):
+            _logger.warning("%s: role '%s' is granted to somebody but has no permission", self._source, role)
+
+        for role in sorted(set(self._permissions) - granted):
+            _logger.warning("%s: role '%s' has permissions but is granted to nobody", self._source, role)
+
+    def get_roles(self, subject: Subject) -> frozenset[str]:
+        """
+        Returns the roles the policy grants to the given subject.
+
+        It reads ``subject.groups``, which is complete only because every provider
+        contributed its groups before any of them was asked for roles.
+
+        :param subject: The subject being authenticated, with its groups resolved
+        :return: The granted role names
+        """
+        return frozenset(
+            role
+            for role in set(self._role_users) | set(self._role_groups)
+            if subject.name in self._role_users.get(role, frozenset())
+            or subject.groups & self._role_groups.get(role, frozenset())
+        )
+
+    def is_permitted(self, subject: Subject, permission: Permission) -> Decision:
+        """
+        Decides whether one of the subject's roles grants the permission.
+
+        **Never returns DENY**, only PERMIT or ABSTAIN: the format expresses grants
+        only, so a policy file can never veto a permission another, looser authorizer
+        allows. That matters as soon as a second authorizer is registered.
+
+        :param subject: The subject to check
+        :param permission: The requested permission
+        :return: PERMIT if a role grants it, ABSTAIN otherwise
+        """
+        for role in subject.roles:
+            for grant in self._permissions.get(role, ()):
+                if grant.implies(permission):
+                    return Decision.PERMIT
+
+        return Decision.ABSTAIN
+
+
+# ------------------------------------------------------------------------------
+
+
+@ComponentFactory(FACTORY_POLICY_FILE)
+@Provides([MembershipProvider, Authorizer, services.FileInstallListener])
+@Property("_policy_path", PROP_POLICY_FILE)
+@Property("_watched_folder", services.PROP_FILEINSTALL_FOLDER)
+class PolicyFile(MembershipProvider, Authorizer, services.FileInstallListener):
+    """
+    Grants roles from users and groups, and permissions to roles, from a TOML file.
+
+    Like the password store, it is reloaded through the File Install service when that
+    bundle is available, and read once at validation otherwise.
+    """
+
+    def __init__(self) -> None:
+        self._policy_path: str = ""
+        self._watched_folder: str = ""
+        self._table: PolicyTable | None = None
+
+    @Validate
+    def _validate(self, _: "BundleContext") -> None:
+        """
+        Component validated: read the file once
+        """
+        if not self._policy_path:
+            raise ValueError(f"No policy file: set the '{PROP_POLICY_FILE}' property")
+
+        self._policy_path = os.path.abspath(self._policy_path)
+        self.reload()
+
+        # Published last, so that File Install does not bind before the file is read
+        self._watched_folder = os.path.dirname(self._policy_path)
+
+    @Invalidate
+    def _invalidate(self, _: "BundleContext") -> None:
+        """
+        Component invalidated
+        """
+        self._watched_folder = ""
+        self._table = None
+
+    def reload(self) -> None:
+        """
+        Reloads the policy file.
+
+        On a parse failure, a shape failure, an empty file or an unreadable one, the
+        **previous table is kept** and an error is logged. A bad policy reload is
+        higher-stakes than a bad user-list reload precisely because it could silently
+        widen access: an empty ``[permissions]`` table parses and denies everything,
+        which is safe, but a truncated file must not be mistaken for that.
+        """
+        try:
+            with open(self._policy_path, encoding="utf-8") as file:
+                text = file.read()
+        except OSError as ex:
+            _logger.error("Error reading %s: %s. Keeping the previous policy", self._policy_path, ex)
+            return
+
+        if not text.strip():
+            _logger.error("%s is empty: keeping the previous policy", self._policy_path)
+            return
+
+        try:
+            table = PolicyTable(text, self._policy_path)
+        except (tomllib.TOMLDecodeError, PolicyError, ValueError) as ex:
+            _logger.error("Error loading %s: %s. Keeping the previous policy", self._policy_path, ex)
+            return
+
+        self._table = table
+
+    # ------------------------------------------------------------------------
+
+    def get_groups(self, subject: Subject) -> Iterable[str]:
+        """
+        A policy asserts no group membership: a group is a fact from an identity source
+        """
+        return ()
+
+    def get_roles(self, subject: Subject) -> Iterable[str]:
+        """
+        Returns the roles the policy grants to the given subject
+        """
+        return self._table.get_roles(subject) if self._table is not None else frozenset()
+
+    def is_permitted(self, subject: Subject, permission: Permission) -> Decision:
+        """
+        Decides whether one of the subject's roles grants the permission
+        """
+        return self._table.is_permitted(subject, permission) if self._table is not None else Decision.ABSTAIN
+
+    def folder_change(
+        self, folder: str, added: Iterable[str], updated: Iterable[str], deleted: Iterable[str]
+    ) -> None:
+        """
+        The File Install service reports a change in the watched folder
+        """
+        if os.path.basename(self._policy_path) in set(added) | set(updated) | set(deleted):
+            _logger.info("Reloading %s", self._policy_path)
+            self.reload()
+
+
+# ------------------------------------------------------------------------------
+
+
+@ComponentFactory(FACTORY_ALLOW_ALL)
+@Provides(Authorizer)
+class AllowAllAuthorizer(Authorizer):
+    """
+    Permits everything, to everybody.
+
+    The deliberate escape hatch: with no authorizer registered every permission is
+    denied, so a test or a development deployment which genuinely wants a permissive
+    answer gets it in one line rather than by weakening a default. It warns every time
+    it validates, so it cannot sit unnoticed in a production configuration.
+    """
+
+    @Validate
+    def _validate(self, _: "BundleContext") -> None:
+        _logger.warning(
+            "The allow-all authorizer is active: every permission is granted to everybody, "
+            "including anonymous callers"
+        )
+
+    def is_permitted(self, subject: Subject, permission: Permission) -> Decision:
+        return Decision.PERMIT

--- a/pelix/threadpool.py
+++ b/pelix/threadpool.py
@@ -25,6 +25,7 @@ Pelix Utilities: Cached thread pool
     limitations under the License.
 """
 
+import contextvars
 import logging
 import queue
 import threading
@@ -165,6 +166,10 @@ class _QueuedTask:
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
     future: FutureResult
+
+    # Context of the caller, to run the task with the same context variables.
+    # Defaulted so that the _STOP sentinel can still be built
+    context: contextvars.Context | None = None
 
 
 _STOP = _QueuedTask(lambda: ..., (), {}, FutureResult())
@@ -343,6 +348,10 @@ class ThreadPool:
         Tasks can be enqueued while the pool is stopped (or not yet started):
         they will be executed once the pool is started.
 
+        The task is executed in a copy of the context of the caller, so it sees the
+        context variables set here, and what it sets reaches neither the caller nor
+        the next task run by the same thread.
+
         :param method: Method to call
         :return: A FutureResult object, to get the result of the task
         :raise ValueError: Invalid method
@@ -356,8 +365,9 @@ class ThreadPool:
 
         # Use a lock, as we might be "resetting" the queue
         with self.__lock:
-            # Add the task to the queue
-            self._queue.put(_QueuedTask(method, args, kwargs, future), True, self._timeout)
+            # Copy the caller context: a reused pool thread must not inherit the previous task's
+            task = _QueuedTask(method, args, kwargs, future, contextvars.copy_context())
+            self._queue.put(task, True, self._timeout)
             self.__nb_pending_task += 1
 
             if self.__nb_pending_task > self.__nb_threads:
@@ -428,7 +438,10 @@ class ThreadPool:
                         self.__nb_active_threads += 1
                     try:
                         # Call the method
-                        task.future.execute(task.method, task.args, task.kwargs)
+                        if task.context is not None:
+                            task.context.run(task.future.execute, task.method, task.args, task.kwargs)
+                        else:
+                            task.future.execute(task.method, task.args, task.kwargs)
                     except Exception:
                         self._logger.exception(
                             "Error executing %s", getattr(task.method, "__name__", repr(task.method))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,12 @@ classifiers = [
 ]
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-dependencies = ["jsonrpclib-pelix>=0.4.3,<1.3.0"]
+dependencies = [
+  "jsonrpclib-pelix>=0.4.3,<1.3.0",
+  # tomllib is in the standard library from Python 3.11: the policy file reader uses
+  # the backport below it, and nothing outside that module knows which one it got
+  "tomli>=2.0; python_version < '3.11'",
+]
 
 [project.urls]
 Homepage = "https://ipopo.readthedocs.io/"
@@ -42,6 +47,7 @@ Source = "http://github.com/tcalmant/ipopo/"
 
 [project.optional-dependencies]
 aiohttp = ["aiohttp>=3.13.5,<3.15.0"]
+bcrypt = ["bcrypt>=4.1,<6.0"]
 etcd2 = ["python-etcd~=0.4.5", "osgiservicebridge~=1.5.9"]
 MQTT = ["paho-mqtt~=2.1.0"]
 Redis = ["redis>=7.4,<8.2"]

--- a/tests/http/test_base.py
+++ b/tests/http/test_base.py
@@ -14,7 +14,7 @@ from pelix import http
 from pelix.framework import Framework, FrameworkFactory
 from pelix.http._base import AbstractHttpService, compute_sub_path, normalize_request_path
 from pelix.http.basic import HttpServiceImpl
-from tests.http.utils import DEFAULT_HOST, get_http_page, install_ipopo, instantiate_server
+from tests.http.utils import DEFAULT_HOST, get_http_code, get_http_page, install_ipopo, instantiate_server
 
 # ------------------------------------------------------------------------------
 
@@ -26,13 +26,24 @@ __version__ = ".".join(str(x) for x in __version_info__)
 
 class SimpleServlet:
     """
-    A servlet which does nothing: only its identity matters here
+    A servlet which does nothing: only its identity and the paths it has been
+    bound to matter here
     """
+
+    def __init__(self) -> None:
+        self.bound: list[str] = []
 
     def do_GET(self, request: Any, response: Any) -> None:
         """
         Does nothing
         """
+
+    def bound_to(self, path: str, parameters: dict[str, Any]) -> bool:
+        """
+        Records the path the servlet has been bound to
+        """
+        self.bound.append(path)
+        return True
 
 
 def get_services() -> list[tuple[str, AbstractHttpService]]:
@@ -89,13 +100,75 @@ class NormalizeRequestPathTest(unittest.TestCase):
         self.assertEqual(normalize_request_path("/path/"), "/path/")
         self.assertEqual(normalize_request_path("/path/?a=1"), "/path/")
 
-    def test_is_idempotent(self) -> None:
+    def test_is_idempotent_on_its_own_result(self) -> None:
         """
-        Normalizing an already normalized path must not change it
+        Normalizing an already normalized path must not change it.
+
+        Note that the normalization is not idempotent on a *raw* path: it
+        decodes, so applying it twice would decode twice. It is called once,
+        on the raw path given by the client.
         """
-        for raw in ("/", "/a/b", "/a/b/", "/a%2Fb"):
+        for raw in ("/", "/a/b", "/a/b/", "/a b"):
             with self.subTest(raw=raw):
                 self.assertEqual(normalize_request_path(normalize_request_path(raw)), raw)
+
+        # Decoding really is applied only once
+        self.assertEqual(normalize_request_path("/a%2520b"), "/a%20b")
+        self.assertEqual(normalize_request_path(normalize_request_path("/a%2520b")), "/a b")
+
+    def test_percent_encoding_is_decoded(self) -> None:
+        """
+        The path is decoded before being routed, so that the servlet and the
+        router can never disagree about what was requested
+        """
+        for raw, expected in (
+            ("/a%20b", "/a b"),
+            ("/%61%62", "/ab"),
+            ("/files/a%2Fb", "/files/a/b"),
+            ("/%2E/a", "/a"),
+        ):
+            with self.subTest(raw=raw):
+                self.assertEqual(normalize_request_path(raw), expected)
+
+    def test_dot_segments_are_resolved(self) -> None:
+        """
+        The ``.`` and ``..`` segments must be resolved before routing
+        """
+        for raw, expected in (
+            ("/a/./b", "/a/b"),
+            ("/public/../admin", "/admin"),
+            ("/public/%2e%2e/admin", "/admin"),
+            ("/public/%2E%2E%2Fadmin", "/admin"),
+            ("/a/b/../c/", "/a/c/"),
+            ("/a/..%2fb", "/b"),
+            ("/a/b/..", "/a"),
+        ):
+            with self.subTest(raw=raw):
+                self.assertEqual(normalize_request_path(raw), expected)
+
+    def test_escaping_the_root_is_refused(self) -> None:
+        """
+        A path resolving above the root must be refused, not clamped to it
+        """
+        for raw in (
+            "/..",
+            "/../..",
+            "/a/../..",
+            "/%2e%2e",
+            "/%2e%2e%2f%2e%2e%2fetc/passwd",
+            "/a/../../b",
+        ):
+            with self.subTest(raw=raw):
+                self.assertRaises(ValueError, normalize_request_path, raw)
+
+    def test_control_characters_are_refused(self) -> None:
+        """
+        A decoded path must not hold a control character: a NUL byte truncates
+        a path for anything calling into C
+        """
+        for raw in ("/a%00b", "/a\x00b", "/a%0Ab", "/a%7Fb", "/a%1fb"):
+            with self.subTest(raw=raw):
+                self.assertRaises(ValueError, normalize_request_path, raw)
 
 
 class ComputeSubPathTest(unittest.TestCase):
@@ -200,6 +273,132 @@ class ResolveRequestTest(unittest.TestCase):
                         self.assertIs(routing.servlet, servlet)
                         self.assertEqual(routing.path, reference.path)
                         self.assertEqual(routing.prefix, reference.prefix)
+
+
+class RefusedPathTest(unittest.TestCase):
+    """
+    Tests the paths the router refuses before looking for a servlet
+    """
+
+    def test_traversal_is_resolved_before_routing(self) -> None:
+        """
+        A path walking back into a servlet must reach that servlet, and the
+        servlet must be given the resolved path
+        """
+        servlet = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                service.register_servlet("/admin", servlet)
+
+                for raw in ("/public/../admin/x", "/public/%2e%2e/admin/x"):
+                    with self.subTest(raw=raw):
+                        routing = service.resolve_request(raw)
+                        self.assertIs(routing.servlet, servlet)
+                        self.assertEqual(routing.prefix, "/admin")
+                        self.assertEqual(routing.path, "/admin/x")
+                        self.assertIsNone(routing.error)
+
+    def test_escaping_the_root_is_a_bad_request(self) -> None:
+        """
+        A path escaping the root is refused with a 400, without any servlet
+        being looked for
+        """
+        servlet = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                service.register_servlet("/test", servlet)
+
+                for raw in ("/..", "/test/../..", "/%2e%2e%2f%2e%2e%2fetc/passwd"):
+                    with self.subTest(raw=raw):
+                        routing = service.resolve_request(raw)
+                        self.assertEqual(routing.error, 400)
+                        self.assertIsNone(routing.servlet)
+
+    def test_control_characters_are_a_bad_request(self) -> None:
+        """
+        A control character in the decoded path is refused with a 400
+        """
+        for name, service in get_services():
+            with self.subTest(service=name):
+                routing = service.resolve_request("/test%00/sub")
+                self.assertEqual(routing.error, 400)
+                self.assertIsNone(routing.servlet)
+
+
+class CaseSensitivityTest(unittest.TestCase):
+    """
+    Tests the case-sensitive matching of the servlet paths
+    """
+
+    def test_paths_are_case_sensitive(self) -> None:
+        """
+        URI paths are case-sensitive: /Admin and /admin are two resources
+        """
+        servlet = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                service.register_servlet("/admin", servlet)
+
+                self.assertIsNotNone(service.get_servlet("/admin/x"))
+                for raw in ("/Admin/x", "/ADMIN/x", "/aDmIn/x"):
+                    with self.subTest(raw=raw):
+                        self.assertIsNone(service.get_servlet(raw))
+
+    def test_registration_keeps_its_case(self) -> None:
+        """
+        A servlet registered on a mixed-case path keeps it, and is reachable
+        on that exact path only. This is what the JSON-RPC, XML-RPC and
+        JABSORB-RPC transports rely on: they advertise the path they declared.
+        """
+        for name, service in get_services():
+            with self.subTest(service=name):
+                # A fresh servlet per service: bound_to is recorded on it
+                servlet = SimpleServlet()
+                self.assertTrue(service.register_servlet("/JSON-RPC", servlet))
+
+                self.assertEqual(service.get_registered_paths(), ["/JSON-RPC"])
+                self.assertIsNotNone(service.get_servlet("/JSON-RPC"))
+                self.assertIsNone(service.get_servlet("/json-rpc"))
+
+                # The servlet has been told the path it asked for
+                self.assertEqual(servlet.bound, ["/JSON-RPC"])
+
+    def test_two_cases_are_two_servlets(self) -> None:
+        """
+        Two paths differing only by their case must not collide
+        """
+        lower = SimpleServlet()
+        upper = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                self.assertTrue(service.register_servlet("/admin", lower))
+                self.assertTrue(service.register_servlet("/Admin", upper))
+
+                found_lower = service.get_servlet("/admin")
+                found_upper = service.get_servlet("/Admin")
+                assert found_lower is not None
+                assert found_upper is not None
+                self.assertIs(found_lower[0], lower)
+                self.assertIs(found_upper[0], upper)
+
+    def test_folding_can_be_restored(self) -> None:
+        """
+        The escape hatch property restores the behaviour of earlier versions
+        """
+        servlet = SimpleServlet()
+        for name, service in get_services():
+            with self.subTest(service=name):
+                service._case_sensitive_paths = False
+                service.register_servlet("/Admin", servlet)
+
+                # Registered folded, reachable in any case
+                self.assertEqual(service.get_registered_paths(), ["/admin"])
+                for raw in ("/admin", "/Admin", "/ADMIN"):
+                    with self.subTest(raw=raw):
+                        self.assertIsNotNone(service.get_servlet(raw))
+
+                self.assertTrue(service.unregister("/ADMIN"))
+                self.assertEqual(service.get_registered_paths(), [])
 
 
 class ServletRegistryTest(unittest.TestCase):
@@ -373,6 +572,9 @@ class EndToEndPathTest(unittest.TestCase):
 
     framework: Framework
 
+    http_bundle: str = "pelix.http.basic"
+    http_factory: str = http.FACTORY_HTTP_BASIC
+
     def setUp(self) -> None:
         """
         Starts a framework with an HTTP server on a random port
@@ -382,9 +584,9 @@ class EndToEndPathTest(unittest.TestCase):
 
         ipopo = install_ipopo(self.framework)
         context = self.framework.get_bundle_context()
-        context.install_bundle("pelix.http.basic").start()
+        context.install_bundle(self.http_bundle).start()
 
-        self.http_svc = instantiate_server(ipopo, http.FACTORY_HTTP_BASIC, "test-http-paths", port=0)
+        self.http_svc = instantiate_server(ipopo, self.http_factory, "test-http-paths", port=0)
         self.port = self.http_svc.get_access()[1]
 
         # Two servlets, one nested in the other
@@ -455,6 +657,93 @@ class EndToEndPathTest(unittest.TestCase):
                 code, content = get_http_page(self.port, DEFAULT_HOST, uri)
                 self.assertEqual(code, 200)
                 self.assertEqual(content.decode("utf-8"), f"inner|/test/inner|{expected}")
+
+    def test_paths_are_case_sensitive(self) -> None:
+        """
+        A request differing from the registration only by its case must not
+        reach that servlet
+        """
+        for uri in ("/Test/inner/x", "/TEST/INNER/x"):
+            with self.subTest(uri=uri):
+                self.assertEqual(get_http_code(self.port, DEFAULT_HOST, uri), 404)
+
+    def test_case_does_not_reach_the_deepest_servlet(self) -> None:
+        """
+        Changing the case of a nested servlet must fall back to the shallower
+        one rather than reach the nested servlet anyway. This is the bypass:
+        the router used to fold the path while the servlet saw the original.
+        """
+        code, content = get_http_page(self.port, DEFAULT_HOST, "/test/Inner/x")
+        self.assertEqual(code, 200)
+        self.assertEqual(content.decode("utf-8"), "root|/test|/Inner/x")
+
+    def test_traversal_is_resolved_before_routing(self) -> None:
+        """
+        A path walking back into a servlet reaches it, and the servlet is given
+        the resolved path: the router and the servlet can never disagree
+        """
+        for uri in (
+            "/test/inner/../inner/x",
+            "/test/sub/../inner/x",
+            "/test/inner/%2e%2e/inner/x",
+            "/test/inner/..%2finner/x",
+        ):
+            with self.subTest(uri=uri):
+                code, content = get_http_page(self.port, DEFAULT_HOST, uri)
+                self.assertEqual(code, 200, f"{uri} did not reach a servlet")
+                self.assertEqual(content.decode("utf-8"), "inner|/test/inner|/x")
+
+    def test_traversal_out_of_a_servlet(self) -> None:
+        """
+        Walking out of the deepest servlet must move the request to the
+        shallower one, not leave a ".." in the sub path
+        """
+        code, content = get_http_page(self.port, DEFAULT_HOST, "/test/inner/../x")
+        self.assertEqual(code, 200)
+        self.assertEqual(content.decode("utf-8"), "root|/test|/x")
+
+    def test_percent_encoding_reaches_the_servlet_decoded(self) -> None:
+        """
+        The servlet is given a decoded sub path
+        """
+        for uri, expected in (
+            ("/test/inner/a%20b", "/a b"),
+            ("/test/inner/a%2Fb", "/a/b"),
+            ("/test/inner/%61%62", "/ab"),
+        ):
+            with self.subTest(uri=uri):
+                code, content = get_http_page(self.port, DEFAULT_HOST, uri)
+                self.assertEqual(code, 200)
+                self.assertEqual(content.decode("utf-8"), f"inner|/test/inner|{expected}")
+
+    def test_escaping_the_root_is_a_bad_request(self) -> None:
+        """
+        A path escaping the root is refused with a 400, not a 404: it is the
+        request which is malformed, not the resource which is missing
+        """
+        for uri in ("/..", "/test/../../x", "/%2e%2e%2f%2e%2e%2fetc/passwd"):
+            with self.subTest(uri=uri):
+                self.assertEqual(get_http_code(self.port, DEFAULT_HOST, uri), 400)
+
+    def test_control_character_is_a_bad_request(self) -> None:
+        """
+        A NUL byte in the decoded path is refused
+        """
+        self.assertEqual(get_http_code(self.port, DEFAULT_HOST, "/test/inner/a%00b"), 400)
+
+
+@unittest.skipIf(importlib.util.find_spec("aiohttp") is None, "aiohttp library not available")
+class AsyncEndToEndPathTest(EndToEndPathTest):
+    """
+    Runs the routing tests over the asynchronous server.
+
+    This is not redundant: the two servers give the router a different string
+    (the raw target here, an already decoded one before this was fixed), so the
+    decoding half of the normalization is only covered on this side.
+    """
+
+    http_bundle = "pelix.http.basic_async"
+    http_factory = http.FACTORY_HTTP_ASYNC
 
 
 # ------------------------------------------------------------------------------

--- a/tests/http/test_contextvars.py
+++ b/tests/http/test_contextvars.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests the propagation of the context variables to the synchronous servlets of the
+asynchronous HTTP service.
+
+:author: Thomas Calmant
+"""
+
+import contextvars
+import importlib.util
+import unittest
+from typing import Any, cast
+
+from pelix import http
+from pelix.framework import Framework, FrameworkFactory, create_framework
+from pelix.ipopo.constants import IPopoService
+from tests.http.utils import DEFAULT_HOST, get_http_page, install_ipopo
+
+if importlib.util.find_spec("aiohttp") is None:
+    raise unittest.SkipTest("aiohttp library not available")
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# ------------------------------------------------------------------------------
+
+_TEST_VAR: contextvars.ContextVar[str] = contextvars.ContextVar("test_var")
+
+
+class ContextServlet:
+    """
+    Servlet which answers the value it sees, then sets a new one
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def do_GET(self, request: http.AbstractHTTPServletRequest, response: Any) -> None:
+        """
+        Answers the current value of the test variable and replaces it
+        """
+        seen = _TEST_VAR.get("unset")
+        self.calls += 1
+        _TEST_VAR.set(f"set-by-request-{self.calls}")
+        response.send_content(200, seen, "text/plain")
+
+
+class AsyncBackendContextTest(unittest.TestCase):
+    """
+    A synchronous servlet of the asynchronous HTTP service runs in a copy of the
+    context of the request, not in the context of the executor thread which happens
+    to be free
+    """
+
+    framework: Framework
+    ipopo: IPopoService
+
+    def setUp(self) -> None:
+        """
+        Prepares a framework with the asynchronous HTTP service
+        """
+        self.framework = create_framework([])
+        self.framework.start()
+        self.ipopo = install_ipopo(self.framework)
+        self.servlet = ContextServlet()
+
+        context = self.framework.get_bundle_context()
+        context.install_bundle("pelix.http.basic_async").start()
+
+        service = cast(
+            http.HTTPService,
+            self.ipopo.instantiate(
+                http.FACTORY_HTTP_ASYNC,
+                "test-http-context",
+                {http.HTTP_SERVICE_ADDRESS: DEFAULT_HOST, http.HTTP_SERVICE_PORT: 0},
+            ),
+        )
+        context.register_service(http.HTTP_SERVLET, self.servlet, {http.HTTP_SERVLET_PATH: "/context"})
+        self.port = service.get_access()[1]
+
+    def tearDown(self) -> None:
+        """
+        Cleans up for the next test
+        """
+        FrameworkFactory.delete_framework(self.framework)
+        self.framework = None  # type: ignore
+
+    def test_no_leak_between_requests(self) -> None:
+        """
+        The executor threads are reused: what a servlet sets must not be visible to
+        the next request handled by the same thread
+        """
+        # More requests than the executor has workers, sent one after the other so
+        # that an idle thread is always available for reuse
+        for _ in range(8):
+            code, data = get_http_page(self.port, DEFAULT_HOST, "/context")
+            self.assertEqual(code, 200)
+            self.assertEqual(data, b"unset", "A previous request leaked its context")
+
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/remote/test_dispatcher_servlet.py
+++ b/tests/remote/test_dispatcher_servlet.py
@@ -246,6 +246,52 @@ class DispatcherTest(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(response, json.dumps(self.framework_uid))
 
+    def _raw_http_get(self, uri: str) -> tuple[int, str]:
+        """
+        Makes a HTTP GET request on the given URI, without any normalization on
+        the client side: the whole point is what the server does with it
+
+        :param uri: The full request URI
+        :return: A (status, response string) tuple
+        """
+        conn = httplib.HTTPConnection("localhost", self.port)
+        conn.request("GET", uri)
+        result = conn.getresponse()
+        data = result.read()
+        conn.close()
+        return result.status, to_str(data)
+
+    def testActionIsNotShiftedByThePathShape(self) -> None:
+        """
+        The action is read from the servlet-relative path, which is normalized.
+
+        It used to be cut out of the raw path by counting segments, so a dot
+        segment shifted it: ``/endpoints/../framework`` listed the end points.
+        Both the normalization and the switch to the sub path close this, and
+        the test pins the result of the two together.
+        """
+        prefix = self.servlet_path.rstrip("/")
+        for uri in (
+            f"{prefix}/framework",
+            f"{prefix}//framework",
+            f"{prefix}/./framework",
+            f"{prefix}/endpoints/../framework",
+        ):
+            with self.subTest(uri=uri):
+                status, response = self._raw_http_get(uri)
+                self.assertEqual(status, 200, f"{uri} did not reach the framework action")
+                self.assertEqual(response, json.dumps(self.framework_uid))
+
+    def testEmptyActionIsNotAnError(self) -> None:
+        """
+        A request on the servlet root used to raise an IndexError, answered as
+        a 500, instead of telling the client its request was incomplete
+        """
+        prefix = self.servlet_path.rstrip("/")
+        for uri in (prefix, f"{prefix}/"):
+            with self.subTest(uri=uri):
+                self.assertEqual(self._raw_http_get(uri)[0], 404)
+
     def testListEndpoints(self) -> None:
         """
         Checks if the list of endpoints is correctly given

--- a/tests/security/__init__.py
+++ b/tests/security/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests of the Pelix security package
+
+:author: Thomas Calmant
+"""

--- a/tests/security/test_beans.py
+++ b/tests/security/test_beans.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests the identity beans of the Pelix security package: Subject, Credentials and
+Permission.
+
+:author: Thomas Calmant
+"""
+
+import unittest
+from types import MappingProxyType
+
+from pelix.security import (
+    ANONYMOUS,
+    Credentials,
+    Decision,
+    Permission,
+    Subject,
+    UsernamePassword,
+)
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# ------------------------------------------------------------------------------
+
+
+class SubjectTest(unittest.TestCase):
+    """
+    Tests the Subject bean
+    """
+
+    def test_defaults(self) -> None:
+        """
+        A bare subject is anonymous-shaped: no group, no role, not authenticated
+        """
+        subject = Subject("bob")
+        self.assertEqual(subject.name, "bob")
+        self.assertEqual(subject.groups, frozenset())
+        self.assertEqual(subject.roles, frozenset())
+        self.assertEqual(dict(subject.attributes), {})
+        self.assertFalse(subject.authenticated)
+        self.assertIsNone(subject.method)
+
+    def test_anonymous_is_not_authenticated(self) -> None:
+        """
+        The shared anonymous subject must never pass an authentication check
+        """
+        self.assertEqual(ANONYMOUS.name, "anonymous")
+        self.assertFalse(ANONYMOUS.authenticated)
+
+    def test_groups_and_roles_are_frozen(self) -> None:
+        """
+        Any iterable is accepted and stored as a frozenset, so a caller cannot keep a
+        mutable reference to the collections of a frozen bean
+        """
+        # Deliberately untyped input: the declared type is frozenset, and the
+        # coercion is what keeps the bean hashable when a caller ignores that
+        groups = ["dev", "ops"]
+        subject = Subject("bob", groups, ("admin",))  # ty: ignore[invalid-argument-type]
+
+        self.assertIsInstance(subject.groups, frozenset)
+        self.assertIsInstance(subject.roles, frozenset)
+        self.assertEqual(subject.groups, {"dev", "ops"})
+        self.assertEqual(subject.roles, {"admin"})
+
+        groups.append("root")
+        self.assertEqual(subject.groups, {"dev", "ops"})
+
+    def test_attributes_are_a_read_only_copy(self) -> None:
+        """
+        frozen=True is not immutability: the caller may still hold the mapping it gave
+        """
+        attributes = {"claim": "value"}
+        subject = Subject("bob", attributes=attributes)
+
+        self.assertIsInstance(subject.attributes, MappingProxyType)
+
+        attributes["claim"] = "other"
+        attributes["added"] = "later"
+        self.assertEqual(dict(subject.attributes), {"claim": "value"})
+
+    def test_attributes_cannot_be_written(self) -> None:
+        """
+        The proxy refuses a write, rather than accepting one nobody else would see
+        """
+        subject = Subject("bob", attributes={"claim": "value"})
+        with self.assertRaises(TypeError):
+            subject.attributes["claim"] = "other"  # ty: ignore[invalid-assignment]
+
+    def test_a_subject_is_hashable(self) -> None:
+        """
+        Which is what compare=False on the unhashable attributes buys
+        """
+        subject = Subject("bob", frozenset({"dev"}), frozenset({"admin"}), {"claim": "value"})
+        self.assertEqual({subject: 1}[subject], 1)
+        self.assertIn(subject, {subject})
+
+    def test_attributes_are_out_of_the_comparison(self) -> None:
+        """
+        The cost of compare=False, stated as a test: two subjects differing only in
+        their attributes are equal, so a session-aware cache keys on the session
+        identifier rather than on the subject
+        """
+        first = Subject("bob", attributes={"pelix.security.session.id": "one"})
+        second = Subject("bob", attributes={"pelix.security.session.id": "two"})
+
+        self.assertEqual(first, second)
+        self.assertEqual(hash(first), hash(second))
+
+    def test_repr_names_the_attribute_keys_only(self) -> None:
+        """
+        The attributes hold raw claims and session handles, so the representation names
+        the keys and never their values
+        """
+        text = repr(Subject("bob", attributes={"id_token": "eyJ-secret", "sub": "1234"}))
+
+        self.assertIn("attributes=[id_token, sub]", text)
+        self.assertNotIn("eyJ-secret", text)
+        self.assertNotIn("1234", text)
+
+    def test_repr_shows_the_rest(self) -> None:
+        """
+        Everything but the attribute values stays visible: the bean must remain
+        debuggable
+        """
+        subject = Subject("bob", frozenset({"dev"}), frozenset({"admin"}), authenticated=True, method="basic")
+        text = repr(subject)
+
+        self.assertIn("name='bob'", text)
+        self.assertIn("groups=['dev']", text)
+        self.assertIn("roles=['admin']", text)
+        self.assertIn("authenticated=True", text)
+        self.assertIn("method='basic'", text)
+
+    def test_names_are_compared_exactly(self) -> None:
+        """
+        No folding, anywhere: two spellings are two identities
+        """
+        self.assertNotEqual(Subject("Bob"), Subject("bob"))
+        self.assertNotIn("dev", Subject("bob", frozenset({"Dev"})).groups)
+        self.assertNotIn("admin", Subject("bob", roles=frozenset({"Admin"})).roles)
+
+
+class CredentialsTest(unittest.TestCase):
+    """
+    Tests the credential beans
+    """
+
+    def test_kinds(self) -> None:
+        """
+        The kind is what an Authenticator is selected on, so it is read off the object
+        """
+        self.assertEqual(Credentials.KIND, "unknown")
+        self.assertEqual(UsernamePassword.KIND, "password")
+        self.assertEqual(UsernamePassword("bob", "hunter2").KIND, "password")
+
+    def test_the_password_is_not_printed(self) -> None:
+        """
+        The generated representation lands in the first log line or traceback which
+        touches the bean
+        """
+        text = repr(UsernamePassword("bob", "hunter2"))
+
+        self.assertIn("bob", text)
+        self.assertNotIn("hunter2", text)
+
+    def test_the_password_is_still_readable(self) -> None:
+        """
+        repr=False hides the field, it does not remove it
+        """
+        self.assertEqual(UsernamePassword("bob", "hunter2").password, "hunter2")
+
+
+class PermissionParseTest(unittest.TestCase):
+    """
+    Tests the parsing of a permission specification
+    """
+
+    def test_action_only(self) -> None:
+        permission = Permission.parse("jobs.submit")
+        self.assertEqual(permission.action, "jobs.submit")
+        self.assertIsNone(permission.resource)
+
+    def test_action_and_resource(self) -> None:
+        permission = Permission.parse("jobs.submit:queue-a")
+        self.assertEqual(permission.action, "jobs.submit")
+        self.assertEqual(permission.resource, "queue-a")
+
+    def test_empty_resource_is_not_absent(self) -> None:
+        """
+        A trailing separator names an empty resource, which matches nothing but itself.
+        The distinction matters: an absent resource is the unscoped grant
+        """
+        permission = Permission.parse("jobs.submit:")
+        self.assertEqual(permission.resource, "")
+
+    def test_empty_action_is_refused(self) -> None:
+        for spec in ("", ":queue-a"):
+            with self.subTest(spec=spec), self.assertRaises(ValueError):
+                Permission.parse(spec)
+
+    def test_str_is_the_parsed_form(self) -> None:
+        for spec in ("jobs.submit", "jobs.submit:queue-a", "*"):
+            with self.subTest(spec=spec):
+                self.assertEqual(str(Permission.parse(spec)), spec)
+
+
+class PermissionImpliesTest(unittest.TestCase):
+    """
+    Tests the matching rule of a permission: three action forms, four resource cases,
+    and both halves must match
+    """
+
+    def test_exact_action(self) -> None:
+        grant = Permission("jobs.submit")
+
+        self.assertTrue(grant.implies(Permission("jobs.submit")))
+        for action in ("jobs", "jobs.submitted", "jobs.submit.now", "Jobs.submit", "config.write"):
+            with self.subTest(action=action):
+                self.assertFalse(grant.implies(Permission(action)))
+
+    def test_prefix_action(self) -> None:
+        grant = Permission("jobs.*")
+
+        for action in ("jobs.submit", "jobs.queue.drain", "jobs."):
+            with self.subTest(action=action):
+                self.assertTrue(grant.implies(Permission(action)))
+
+        # "jobs.*" does not cover "jobs" itself, and does not leak into a sibling prefix
+        for action in ("jobs", "jobsx.submit", "Jobs.submit"):
+            with self.subTest(action=action):
+                self.assertFalse(grant.implies(Permission(action)))
+
+    def test_the_single_all_grant_form(self) -> None:
+        grant = Permission("*")
+
+        for action in ("jobs", "jobs.submit", "config.write.everything"):
+            with self.subTest(action=action):
+                self.assertTrue(grant.implies(Permission(action)))
+
+    def test_unscoped_grant_matches_any_resource(self) -> None:
+        grant = Permission("jobs.submit")
+
+        self.assertTrue(grant.implies(Permission("jobs.submit")))
+        self.assertTrue(grant.implies(Permission("jobs.submit", "queue-a")))
+
+    def test_wildcard_resource_matches_any_resource(self) -> None:
+        grant = Permission("jobs.submit", "*")
+
+        self.assertTrue(grant.implies(Permission("jobs.submit")))
+        self.assertTrue(grant.implies(Permission("jobs.submit", "queue-a")))
+
+    def test_scoped_grant_matches_that_resource_only(self) -> None:
+        grant = Permission("jobs.submit", "queue-a")
+
+        self.assertTrue(grant.implies(Permission("jobs.submit", "queue-a")))
+        self.assertFalse(grant.implies(Permission("jobs.submit", "queue-b")))
+        self.assertFalse(grant.implies(Permission("jobs.submit", "Queue-a")))
+
+    def test_scoped_grant_does_not_satisfy_an_unscoped_request(self) -> None:
+        """
+        The safe direction, and the one a method-level declaration relies on: a
+        per-queue grant does not satisfy a plain "jobs.submit"
+        """
+        self.assertFalse(Permission("jobs.submit", "queue-a").implies(Permission("jobs.submit")))
+
+    def test_both_halves_must_match(self) -> None:
+        self.assertFalse(Permission("jobs.*", "queue-a").implies(Permission("config.write", "queue-a")))
+        self.assertFalse(Permission("jobs.*", "queue-a").implies(Permission("jobs.submit", "queue-b")))
+        self.assertTrue(Permission("jobs.*", "queue-a").implies(Permission("jobs.submit", "queue-a")))
+
+
+class DecisionTest(unittest.TestCase):
+    """
+    Tests the decision enumeration
+    """
+
+    def test_the_three_values(self) -> None:
+        """
+        Three and not two: abstain is what lets independent policies compose
+        """
+        self.assertEqual({decision.value for decision in Decision}, {"permit", "deny", "abstain"})
+
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/security/test_context.py
+++ b/tests/security/test_context.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests the current subject of the Pelix security package: the context variable,
+get_current_subject() and run_as().
+
+:author: Thomas Calmant
+"""
+
+import asyncio
+import contextvars
+import threading
+import unittest
+
+from pelix.security import _SUBJECT, ANONYMOUS, Subject, get_current_subject, run_as
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# ------------------------------------------------------------------------------
+
+ALICE = Subject("alice", roles=frozenset({"admin"}), authenticated=True)
+BOB = Subject("bob", roles=frozenset({"operator"}), authenticated=True)
+
+# ------------------------------------------------------------------------------
+
+
+class CurrentSubjectTest(unittest.TestCase):
+    """
+    Tests get_current_subject() and run_as()
+    """
+
+    def test_nothing_published_is_anonymous(self) -> None:
+        """
+        The default is the anonymous subject, not None: a caller never has to guard
+        """
+        self.assertIs(get_current_subject(), ANONYMOUS)
+
+    def test_run_as_publishes_and_restores(self) -> None:
+        with run_as(ALICE):
+            self.assertIs(get_current_subject(), ALICE)
+
+        self.assertIs(get_current_subject(), ANONYMOUS)
+
+    def test_run_as_nests(self) -> None:
+        with run_as(ALICE):
+            with run_as(BOB):
+                self.assertIs(get_current_subject(), BOB)
+
+            self.assertIs(get_current_subject(), ALICE)
+
+        self.assertIs(get_current_subject(), ANONYMOUS)
+
+    def test_run_as_restores_on_exception(self) -> None:
+        """
+        The reset lives in a finally: an escaping exception must not leave an identity
+        published behind it
+        """
+        with self.assertRaises(ValueError), run_as(ALICE):
+            raise ValueError("boom")
+
+        self.assertIs(get_current_subject(), ANONYMOUS)
+
+
+class PropagationTest(unittest.TestCase):
+    """
+    The current subject follows the standard Python context: wherever a context
+    propagates, the subject propagates, and nowhere else
+    """
+
+    def test_a_copied_context_carries_it(self) -> None:
+        with run_as(ALICE):
+            context = contextvars.copy_context()
+
+        self.assertEqual(context.run(get_current_subject), ALICE)
+
+    def test_a_bare_thread_starts_anonymous(self) -> None:
+        """
+        A new thread starts with an empty context, so code crossing that boundary copies
+        it explicitly. Stated as a test, because the failure is silent otherwise
+        """
+        seen: list[Subject] = []
+
+        with run_as(ALICE):
+            thread = threading.Thread(target=lambda: seen.append(get_current_subject()))
+            thread.start()
+            thread.join()
+
+        self.assertIs(seen[0], ANONYMOUS)
+
+    def test_a_thread_running_a_copied_context_carries_it(self) -> None:
+        """
+        And the explicit copy is what fixes it
+        """
+        seen: list[Subject] = []
+
+        with run_as(ALICE):
+            context = contextvars.copy_context()
+            thread = threading.Thread(target=lambda: seen.append(context.run(get_current_subject)))
+            thread.start()
+            thread.join()
+
+        self.assertEqual(seen[0], ALICE)
+
+    def test_a_task_inherits_the_context_of_its_creator(self) -> None:
+        async def read() -> Subject:
+            return get_current_subject()
+
+        async def main() -> tuple[Subject, Subject]:
+            with run_as(ALICE):
+                inside = await asyncio.create_task(read())
+
+            outside = await asyncio.create_task(read())
+            return inside, outside
+
+        inside, outside = asyncio.run(main())
+        self.assertEqual(inside, ALICE)
+        self.assertIs(outside, ANONYMOUS)
+
+    def test_a_task_does_not_publish_back_to_its_creator(self) -> None:
+        """
+        A Task runs in a copy, so an identity it publishes and never takes back stays
+        inside it
+        """
+
+        async def elevate() -> None:
+            # Deliberately without the reset run_as() would do
+            _SUBJECT.set(BOB)
+
+        async def main() -> Subject:
+            with run_as(ALICE):
+                await asyncio.create_task(elevate())
+                return get_current_subject()
+
+        self.assertEqual(asyncio.run(main()), ALICE)
+
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/security/test_core.py
+++ b/tests/security/test_core.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests the identity pipeline and the authorization facade of the security core.
+
+:author: Thomas Calmant
+"""
+
+import importlib
+import unittest
+from collections.abc import Iterable
+from typing import Any
+
+import pelix.framework
+from pelix.constants import SERVICE_RANKING
+from pelix.security import (
+    ANONYMOUS,
+    PROP_CREDENTIAL_KINDS,
+    AccessDenied,
+    AuthenticationFailed,
+    Authenticator,
+    Authorization,
+    Authorizer,
+    Credentials,
+    Decision,
+    MembershipProvider,
+    Permission,
+    Subject,
+    UsernamePassword,
+    run_as,
+    use_authorization,
+)
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# ------------------------------------------------------------------------------
+
+
+class FakeAuthenticator(Authenticator):
+    """
+    Knows a fixed set of user names and passwords
+    """
+
+    def __init__(self, users: dict[str, str]) -> None:
+        self.users = users
+        self.calls: list[str] = []
+
+    def authenticate(self, credentials: Credentials) -> Subject | None:
+        assert isinstance(credentials, UsernamePassword)
+        self.calls.append(credentials.username)
+
+        try:
+            expected = self.users[credentials.username]
+        except KeyError:
+            # Unknown user: abstain, so that a lower-ranked store may still answer
+            return None
+
+        if expected != credentials.password:
+            # Known user, wrong password: stop the loop, or the next store becomes an
+            # oracle for the credentials this one just rejected
+            raise AuthenticationFailed(credentials.username)
+
+        return Subject(credentials.username)
+
+
+class FakeGroups(MembershipProvider):
+    """
+    Contributes groups, from a fixed table
+    """
+
+    def __init__(self, groups: dict[str, set[str]]) -> None:
+        self.groups = groups
+        self.seen_by_get_roles: list[Subject] = []
+
+    def get_groups(self, subject: Subject) -> Iterable[str]:
+        return self.groups.get(subject.name, set())
+
+    def get_roles(self, subject: Subject) -> Iterable[str]:
+        self.seen_by_get_roles.append(subject)
+        return ()
+
+
+class FakeRolesFromGroups(MembershipProvider):
+    """
+    Contributes roles derived from the groups another provider asserted
+    """
+
+    def __init__(self, roles: dict[str, set[str]]) -> None:
+        self.roles = roles
+
+    def get_groups(self, subject: Subject) -> Iterable[str]:
+        return ()
+
+    def get_roles(self, subject: Subject) -> Iterable[str]:
+        granted: set[str] = set()
+        for group in subject.groups:
+            granted.update(self.roles.get(group, set()))
+
+        return granted
+
+
+class FakeAuthorizer(Authorizer):
+    """
+    Answers a fixed decision, whatever it is asked
+    """
+
+    def __init__(self, decision: Decision) -> None:
+        self.decision = decision
+        self.calls: list[Permission] = []
+
+    def is_permitted(self, subject: Subject, permission: Permission) -> Decision:
+        self.calls.append(permission)
+        return self.decision
+
+
+class BrokenAuthorizer(Authorizer):
+    """
+    Raises rather than deciding
+    """
+
+    def is_permitted(self, subject: Subject, permission: Permission) -> Decision:
+        raise RuntimeError("the policy backend is down")
+
+
+# ------------------------------------------------------------------------------
+
+
+def live_core() -> Any:
+    """
+    Returns the pelix.security.core module the running framework loaded.
+
+    Uninstalling a bundle drops its module from ``sys.modules`` to force a complete
+    reload if it is re-installed, so a reference taken when this test module was
+    imported would go stale after the first framework is deleted.
+
+    Typed as Any rather than ModuleType, so that a test may reach the module-level
+    state it has to reset between runs.
+
+    :return: The module currently backing the bundle
+    """
+    return importlib.import_module("pelix.security.core")
+
+
+class CoreTestCase(unittest.TestCase):
+    """
+    Common framework fixture: the security core bundle, and nothing else
+    """
+
+    framework: pelix.framework.Framework
+
+    def setUp(self) -> None:
+        self.framework = pelix.framework.create_framework(("pelix.security.core",))
+        self.addCleanup(self.framework.delete, True)
+        self.framework.start()
+        self.context = self.framework.get_bundle_context()
+        self.core = live_core()
+
+        # The "warn once" state is module-level, so a test which expects a warning must
+        # not depend on which tests ran before it
+        self.core._warned_kinds.clear()
+        self.core._warned_no_authorizer = False
+
+    def register(self, specification: Any, service: Any, ranking: int = 0, **properties: Any) -> Any:
+        """
+        Registers a service at a chosen ranking
+
+        :param specification: The specification to register under
+        :param service: The service object
+        :param ranking: Its service.ranking
+        :param properties: Other service properties
+        :return: The service registration
+        """
+        return self.context.register_service(specification, service, {SERVICE_RANKING: ranking, **properties})
+
+    def register_authenticator(self, users: dict[str, str], ranking: int = 0) -> FakeAuthenticator:
+        authenticator = FakeAuthenticator(users)
+        self.register(Authenticator, authenticator, ranking, **{PROP_CREDENTIAL_KINDS: ("password",)})
+        return authenticator
+
+
+class AuthenticateTest(CoreTestCase):
+    """
+    Tests the authentication half of the pipeline
+    """
+
+    def test_a_good_password_gives_an_authenticated_subject(self) -> None:
+        self.register_authenticator({"alice": "good"})
+
+        subject = self.core.authenticate(UsernamePassword("alice", "good"))
+
+        self.assertEqual(subject.name, "alice")
+        self.assertTrue(subject.authenticated)
+
+    def test_the_pipeline_owns_the_authenticated_flag(self) -> None:
+        """
+        An authenticator is responsible for the name only: one which forgets the flag
+        cannot produce a subject which passes nothing
+        """
+        self.register_authenticator({"alice": "good"})
+
+        self.assertTrue(self.core.authenticate(UsernamePassword("alice", "good")).authenticated)
+
+    def test_the_method_is_left_to_the_transport(self) -> None:
+        """
+        It names the mechanism, which is what a transport-neutral pipeline cannot know
+        """
+        self.register_authenticator({"alice": "good"})
+
+        self.assertIsNone(self.core.authenticate(UsernamePassword("alice", "good")).method)
+
+    def test_a_wrong_password_is_refused(self) -> None:
+        self.register_authenticator({"alice": "good"})
+
+        with self.assertRaises(AuthenticationFailed):
+            self.core.authenticate(UsernamePassword("alice", "wrong"))
+
+    def test_no_authenticator_refuses_rather_than_answering_anonymous(self) -> None:
+        """
+        A caller which presented credentials and got back an unauthenticated subject
+        cannot tell that apart from a wrong password, and the two need different
+        diagnostics
+        """
+        with self.assertRaises(AuthenticationFailed), self.assertLogs(self.core.__name__, "WARNING"):
+            self.core.authenticate(UsernamePassword("alice", "good"))
+
+    def test_an_authenticator_not_declaring_its_kinds_is_reported(self) -> None:
+        """
+        The kind property is mandatory, so the likely cause is a store which forgot it
+        rather than one which is absent. The message has to say which
+        """
+        self.register(Authenticator, FakeAuthenticator({"alice": "good"}))
+
+        with self.assertRaises(AuthenticationFailed), self.assertLogs(self.core.__name__, "WARNING") as logs:
+            self.core.authenticate(UsernamePassword("alice", "good"))
+
+        self.assertIn(PROP_CREDENTIAL_KINDS, logs.output[0])
+
+    def test_an_unknown_user_falls_through_to_the_next_store(self) -> None:
+        """
+        Returning None abstains, which is what lets several stores compose
+        """
+        first = self.register_authenticator({"alice": "good"}, ranking=10)
+        second = self.register_authenticator({"bob": "good"}, ranking=0)
+
+        subject = self.core.authenticate(UsernamePassword("bob", "good"))
+
+        self.assertEqual(subject.name, "bob")
+        self.assertEqual(first.calls, ["bob"])
+        self.assertEqual(second.calls, ["bob"])
+
+    def test_a_rejection_stops_the_loop(self) -> None:
+        """
+        The heart of the three-state contract. Without it, an emergency store holding an
+        old password for a user the main store already rejected keeps working forever:
+        a credential oracle the loop itself creates
+        """
+        main = self.register_authenticator({"alice": "good"}, ranking=10)
+        emergency = self.register_authenticator({"alice": "old-password"}, ranking=0)
+
+        with self.assertRaises(AuthenticationFailed):
+            self.core.authenticate(UsernamePassword("alice", "old-password"))
+
+        self.assertEqual(main.calls, ["alice"])
+        self.assertEqual(emergency.calls, [], "The lower-ranked store must not be consulted")
+
+    def test_the_stores_are_consulted_in_ranking_order(self) -> None:
+        low = self.register_authenticator({"alice": "low"}, ranking=0)
+        high = self.register_authenticator({"alice": "high"}, ranking=10)
+
+        subject = self.core.authenticate(UsernamePassword("alice", "high"))
+
+        self.assertEqual(subject.name, "alice")
+        self.assertEqual(high.calls, ["alice"])
+        self.assertEqual(low.calls, [])
+
+    def test_a_store_registered_later_is_still_ranked(self) -> None:
+        """
+        The registry is queried on every call rather than injected once, because an
+        aggregate injection appends what arrives later instead of ordering it
+        """
+        self.register_authenticator({"alice": "low"}, ranking=0)
+        high = self.register_authenticator({"alice": "high"}, ranking=10)
+
+        self.core.authenticate(UsernamePassword("alice", "high"))
+        self.assertEqual(high.calls, ["alice"])
+
+
+class MembershipTest(CoreTestCase):
+    """
+    Tests the two membership passes
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.register_authenticator({"alice": "good"})
+
+    def test_groups_are_unioned(self) -> None:
+        self.register(MembershipProvider, FakeGroups({"alice": {"dev"}}))
+        self.register(MembershipProvider, FakeGroups({"alice": {"ops"}}))
+
+        subject = self.core.authenticate(UsernamePassword("alice", "good"))
+        self.assertEqual(subject.groups, {"dev", "ops"})
+
+    def test_roles_are_unioned(self) -> None:
+        self.register(MembershipProvider, FakeRolesFromGroups({"dev": {"admin"}}))
+        self.register(MembershipProvider, FakeGroups({"alice": {"dev"}}))
+
+        subject = self.core.authenticate(UsernamePassword("alice", "good"))
+        self.assertEqual(subject.roles, {"admin"})
+
+    def test_the_roles_pass_sees_the_complete_groups(self) -> None:
+        """
+        This is what the two passes buy, and it is the step a single pass would silently
+        lose: the provider granting roles is registered *first*, so with one pass it
+        would look at a subject whose groups are still empty and answer nothing
+        """
+        self.register(MembershipProvider, FakeRolesFromGroups({"dev": {"admin"}}), ranking=100)
+        self.register(MembershipProvider, FakeGroups({"alice": {"dev"}}), ranking=0)
+
+        subject = self.core.authenticate(UsernamePassword("alice", "good"))
+
+        self.assertEqual(subject.groups, {"dev"})
+        self.assertEqual(subject.roles, {"admin"})
+
+    def test_the_groups_pass_sees_no_role(self) -> None:
+        """
+        Stated the other way round: derivation goes one way only, and get_groups() must
+        not look at subject.roles, which is empty there by construction
+        """
+        groups = FakeGroups({"alice": {"dev"}})
+        self.register(MembershipProvider, groups)
+        self.register(MembershipProvider, FakeRolesFromGroups({"dev": {"admin"}}))
+
+        self.core.authenticate(UsernamePassword("alice", "good"))
+
+        self.assertEqual(len(groups.seen_by_get_roles), 1)
+        self.assertEqual(groups.seen_by_get_roles[0].groups, {"dev"})
+        self.assertEqual(groups.seen_by_get_roles[0].roles, frozenset())
+
+    def test_names_are_taken_verbatim(self) -> None:
+        """
+        The union is a plain set union: the core does not transform what a provider
+        returned, because only the provider knows the matching rule of its own source
+        """
+        self.register(MembershipProvider, FakeGroups({"alice": {"Dev-Leads"}}))
+
+        subject = self.core.authenticate(UsernamePassword("alice", "good"))
+        self.assertEqual(subject.groups, {"Dev-Leads"})
+
+    def test_no_provider_gives_an_empty_membership(self) -> None:
+        subject = self.core.authenticate(UsernamePassword("alice", "good"))
+
+        self.assertEqual(subject.groups, frozenset())
+        self.assertEqual(subject.roles, frozenset())
+
+
+class AuthorizationTest(CoreTestCase):
+    """
+    Tests the authorization facade and its combining rule
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        reference = self.context.get_service_reference(Authorization)
+        assert reference is not None
+        self.authorization: Authorization = self.context.get_service(reference)
+
+    def test_the_service_is_published(self) -> None:
+        with use_authorization(self.context) as authorization:
+            self.assertIsNotNone(authorization)
+
+    def test_no_authorizer_denies(self) -> None:
+        """
+        You cannot get permissive by accident
+        """
+        with self.assertLogs(self.core.__name__, "WARNING"):
+            self.assertFalse(self.authorization.is_permitted(Permission("jobs.submit")))
+
+    def test_a_permit_permits(self) -> None:
+        self.register(Authorizer, FakeAuthorizer(Decision.PERMIT))
+        self.assertTrue(self.authorization.is_permitted(Permission("jobs.submit")))
+
+    def test_an_abstention_alone_denies(self) -> None:
+        self.register(Authorizer, FakeAuthorizer(Decision.ABSTAIN))
+        self.assertFalse(self.authorization.is_permitted(Permission("jobs.submit")))
+
+    def test_an_abstention_lets_another_policy_decide(self) -> None:
+        self.register(Authorizer, FakeAuthorizer(Decision.ABSTAIN))
+        self.register(Authorizer, FakeAuthorizer(Decision.PERMIT))
+
+        self.assertTrue(self.authorization.is_permitted(Permission("jobs.submit")))
+
+    def test_any_deny_wins(self) -> None:
+        """
+        Whatever its ranking: the rule is not "the best-ranked one decides"
+        """
+        self.register(Authorizer, FakeAuthorizer(Decision.PERMIT), ranking=0)
+        self.register(Authorizer, FakeAuthorizer(Decision.DENY), ranking=-10)
+
+        self.assertFalse(self.authorization.is_permitted(Permission("jobs.submit")))
+
+    def test_a_deny_wins_over_a_lower_ranked_permit(self) -> None:
+        self.register(Authorizer, FakeAuthorizer(Decision.DENY), ranking=10)
+        self.register(Authorizer, FakeAuthorizer(Decision.PERMIT), ranking=0)
+
+        self.assertFalse(self.authorization.is_permitted(Permission("jobs.submit")))
+
+    def test_a_broken_authorizer_denies(self) -> None:
+        """
+        An authorizer which cannot decide has not decided, and continuing would let a
+        broken policy open a door
+        """
+        self.register(Authorizer, BrokenAuthorizer())
+        self.register(Authorizer, FakeAuthorizer(Decision.PERMIT))
+
+        with self.assertLogs(self.core.__name__, "ERROR"):
+            self.assertFalse(self.authorization.is_permitted(Permission("jobs.submit")))
+
+    def test_the_current_subject_is_used_by_default(self) -> None:
+        authorizer = FakeAuthorizer(Decision.PERMIT)
+        self.register(Authorizer, authorizer)
+
+        alice = Subject("alice", authenticated=True)
+        with run_as(alice):
+            self.assertTrue(self.authorization.is_permitted(Permission("jobs.submit")))
+
+    def test_check_permitted_raises(self) -> None:
+        self.register(Authorizer, FakeAuthorizer(Decision.DENY))
+
+        with self.assertRaises(AccessDenied):
+            self.authorization.check_permitted(Permission("jobs.submit"))
+
+    def test_check_permitted_returns_on_success(self) -> None:
+        self.register(Authorizer, FakeAuthorizer(Decision.PERMIT))
+        self.assertIsNone(self.authorization.check_permitted(Permission("jobs.submit")))
+
+    def test_has_role_and_in_group_read_the_subject(self) -> None:
+        alice = Subject("alice", frozenset({"dev"}), frozenset({"admin"}), authenticated=True)
+
+        self.assertTrue(self.authorization.has_role("admin", alice))
+        self.assertFalse(self.authorization.has_role("operator", alice))
+        self.assertTrue(self.authorization.in_group("dev", alice))
+        self.assertFalse(self.authorization.in_group("ops", alice))
+
+    def test_has_role_and_in_group_compare_exactly(self) -> None:
+        alice = Subject("alice", frozenset({"Dev"}), frozenset({"Admin"}), authenticated=True)
+
+        self.assertFalse(self.authorization.has_role("admin", alice))
+        self.assertFalse(self.authorization.in_group("dev", alice))
+
+    def test_the_default_subject_is_anonymous(self) -> None:
+        self.assertFalse(self.authorization.has_role("admin"))
+        self.assertFalse(self.authorization.in_group("dev"))
+
+
+class LifecycleTest(unittest.TestCase):
+    """
+    Tests what starting and stopping the bundle does to the single decorator slot
+    """
+
+    def test_the_slot_is_filled_and_cleared(self) -> None:
+        from pelix.security import decorators
+
+        self.assertIsNone(decorators._authorization)
+
+        framework = pelix.framework.create_framework(())
+        framework.start()
+        try:
+            bundle = framework.get_bundle_context().install_bundle("pelix.security.core")
+            bundle.start()
+            self.assertIsNotNone(decorators._authorization)
+
+            bundle.stop()
+            self.assertIsNone(decorators._authorization)
+        finally:
+            framework.delete(True)
+
+    def test_authenticate_needs_the_bundle(self) -> None:
+        """
+        With the bundle stopped there is no registry to consult, so authentication
+        refuses rather than answering anonymous
+        """
+        with self.assertRaises(AuthenticationFailed):
+            live_core().authenticate(UsernamePassword("alice", "good"))
+
+
+class AnonymousTest(CoreTestCase):
+    """
+    The anonymous subject holds nothing, so it satisfies nothing
+    """
+
+    def test_it_holds_no_role_and_no_group(self) -> None:
+        reference = self.context.get_service_reference(Authorization)
+        assert reference is not None
+        authorization: Authorization = self.context.get_service(reference)
+
+        self.assertFalse(authorization.has_role("admin", ANONYMOUS))
+        self.assertFalse(authorization.in_group("dev", ANONYMOUS))
+
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/security/test_crypt.py
+++ b/tests/security/test_crypt.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests the verification of the password hashes a .htpasswd file can hold.
+
+The vectors of the SHA-crypt classes are the ones published with the algorithm; the
+others were produced by ``openssl passwd`` and cross-checked against the system
+``libcrypt``. They are hard-coded rather than generated: a test which computes its own
+expectation with the code under test proves nothing here.
+
+:author: Thomas Calmant
+"""
+
+import importlib.util
+import unittest
+from typing import ClassVar
+
+from pelix.security import _crypt
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# ------------------------------------------------------------------------------
+
+
+class ClassifyTest(unittest.TestCase):
+    """
+    Tests the recognition of the stored formats
+    """
+
+    def test_the_supported_schemes(self) -> None:
+        cases = {
+            "{SHA}qZk+NkcGgWq6PiVxeFDCbJzQ2J0=": _crypt.Scheme.SHA1,
+            "$apr1$Salt1234$D8s.gsdmZE5tKuG05Ln6h1": _crypt.Scheme.APR1,
+            "$5$Salt1234$fkaLpRxzw5AmCunoMxKXYbdYIEdpMtjffBTHgpMkbJB": _crypt.Scheme.SHA256,
+            "$6$Salt1234$6PKOWHd4Jx": _crypt.Scheme.SHA512,
+        }
+        for stored, scheme in cases.items():
+            with self.subTest(scheme=scheme):
+                self.assertEqual(_crypt.classify(stored), scheme)
+
+    def test_des_crypt_is_refused(self) -> None:
+        """
+        Eight-character truncation and a twelve-bit salt, and unimplementable on a
+        modern Python anyway
+        """
+        with self.assertRaises(_crypt.UnsupportedHash) as context:
+            _crypt.classify("rEK1ecacw.rKc")
+
+        self.assertIn("htpasswd -5", str(context.exception))
+
+    def test_anything_else_is_plaintext(self) -> None:
+        """
+        "Support plaintext" and "refuse unknown formats" are the same branch with
+        opposite defaults, and the caller owns the default
+        """
+        for stored in ("hunter2", "", "$9$unknown$scheme", "{MD5}abcd"):
+            with self.subTest(stored=stored):
+                self.assertEqual(_crypt.classify(stored), _crypt.Scheme.PLAINTEXT)
+
+
+class Sha1Test(unittest.TestCase):
+    """
+    Tests {SHA}, the unsalted base64 SHA-1 of htpasswd -s
+    """
+
+    # base64(sha1(b"abc")), as htpasswd -s writes it
+    VECTOR = "{SHA}qZk+NkcGgWq6PiVxeFDCbJzQ2J0="
+
+    def test_the_vector(self) -> None:
+        self.assertTrue(_crypt.verify("abc", self.VECTOR))
+
+    def test_a_wrong_password(self) -> None:
+        self.assertFalse(_crypt.verify("abd", self.VECTOR))
+
+    def test_an_empty_password(self) -> None:
+        self.assertTrue(_crypt.verify("", "{SHA}2jmj7l5rSw0yVb/vlWAYkK/YBwk="))
+
+
+class Apr1Test(unittest.TestCase):
+    """
+    Tests $apr1$, the Apache MD5 construction
+    """
+
+    VECTORS: ClassVar[dict[str, str]] = {
+        "": "$apr1$Salt1234$RJ65UuCD1ZSOkdcQd0Nq7/",
+        "a": "$apr1$Salt1234$oE0AI8r/6R5rEU7EzDQq3.",
+        "hunter2": "$apr1$Salt1234$SGnju/duP8ZqWvqbs1MkB1",
+        "good": "$apr1$FGkY6bLp$IKkCuz1P..KyQ0FL0L7Ir0",
+        # Non-ASCII, to pin that the password is hashed as the bytes it really is
+        "pässwörd": "$apr1$Salt1234$W4qW/8xhDkglbB.JlEmC.0",
+        # Longer than one MD5 block, which exercises the folding loop
+        "0123456789012345678901234567890123456789": "$apr1$Salt1234$CpTUIPIAsdGBCsIjtkeEc1",
+    }
+
+    def test_the_vectors(self) -> None:
+        for password, stored in self.VECTORS.items():
+            with self.subTest(password=password):
+                self.assertTrue(_crypt.verify(password, stored))
+
+    def test_a_wrong_password(self) -> None:
+        for password, stored in self.VECTORS.items():
+            with self.subTest(password=password):
+                self.assertFalse(_crypt.verify(f"{password}x", stored))
+
+    def test_the_salt_is_kept(self) -> None:
+        self.assertEqual(_crypt.apr1("hunter2", "Salt1234"), self.VECTORS["hunter2"])
+
+    def test_the_salt_is_capped_at_eight_characters(self) -> None:
+        """
+        The format allows no more, and Apache silently truncates: a longer salt gives
+        the very same digest
+        """
+        self.assertEqual(_crypt.apr1("hunter2", "Salt1234567890")[-22:], self.VECTORS["hunter2"][-22:])
+
+
+class ShaCryptTest(unittest.TestCase):
+    """
+    Tests $5$ and $6$, the SHA-crypt construction.
+
+    $6$ is not a SHA-512 of the salted password: it is a fixed multi-step digest
+    procedure using SHA-512 as its primitive, repeated 5000 times by default. The
+    vectors below come with the algorithm.
+    """
+
+    SHA256_VECTORS: ClassVar[dict[tuple[str, str], str]] = {
+        ("Hello world!", "$5$saltstring"): "$5$saltstring$5B8vYYiY.CVt1RlTTf8KbXBH3hsxY/GNooZaBBGWEc5",
+        ("Hello world!", "$5$rounds=10000$saltstringsaltstring"): (
+            "$5$rounds=10000$saltstringsaltst$3xv.VbSHBb41AL9AvLeujZkZRBAwqFMz2.opqey6IcA"
+        ),
+        ("This is just a test", "$5$rounds=5000$toolongsaltstring"): (
+            "$5$rounds=5000$toolongsaltstrin$Un/5jzAHMgOGZ5.mWJpuVolil07guHPvOW8mGRcvxa5"
+        ),
+        (
+            "a very much longer text to encrypt.  This one even stretches over morethan one line.",
+            "$5$rounds=1400$anotherlongsaltstring",
+        ): ("$5$rounds=1400$anotherlongsalts$Rx.j8H.h8HjEDGomFU8bDkXm3XIUnzyxf12oP84Bnq1"),
+        ("we have a short salt string but not a short password", "$5$rounds=77777$short"): (
+            "$5$rounds=77777$short$JiO1O3ZpDAxGJeaDIuqCoEFysAe1mZNJRs3pw0KQRd/"
+        ),
+    }
+
+    SHA512_VECTORS: ClassVar[dict[tuple[str, str], str]] = {
+        ("Hello world!", "$6$saltstring"): (
+            "$6$saltstring$svn8UoSVapNtMuq1ukKS4tPQd8iKwSMHWjl/O817G3uBnIFNjnQJu"
+            "esI68u4OTLiBFdcbYEdFCoEOfaS35inz1"
+        ),
+        ("Hello world!", "$6$rounds=10000$saltstringsaltstring"): (
+            "$6$rounds=10000$saltstringsaltst$OW1/O6BYHV6BcXZu8QVeXbDWra3Oeqh0sb"
+            "HbbMCVNSnCM/UrjmM0Dp8vOuZeHBy/YTBmSK6H9qs/y3RnOaw5v."
+        ),
+        ("This is just a test", "$6$rounds=5000$toolongsaltstring"): (
+            "$6$rounds=5000$toolongsaltstrin$lQ8jolhgVRVhY4b5pZKaysCLi0QBxGoNeKQ"
+            "zQ3glMhwllF7oGDZxUhx1yxdYcz/e1JSbq3y6JMxxl8audkUEm0"
+        ),
+        ("we have a short salt string but not a short password", "$6$rounds=77777$short"): (
+            "$6$rounds=77777$short$WuQyW2YR.hBNpjjRhpYD/ifIw05xdfeEyQoMxIXbkvr0g"
+            "ge1a1x3yRULJ5CCaUeOxFmtlcGZelFl5CxtgfiAc0"
+        ),
+    }
+
+    def test_the_sha256_vectors(self) -> None:
+        for (password, setting), expected in self.SHA256_VECTORS.items():
+            with self.subTest(setting=setting):
+                self.assertEqual(_crypt.sha_crypt(password, expected, _crypt.Scheme.SHA256), expected)
+                self.assertTrue(_crypt.verify(password, expected))
+
+    def test_the_sha512_vectors(self) -> None:
+        for (password, setting), expected in self.SHA512_VECTORS.items():
+            with self.subTest(setting=setting):
+                self.assertEqual(_crypt.sha_crypt(password, expected, _crypt.Scheme.SHA512), expected)
+                self.assertTrue(_crypt.verify(password, expected))
+
+    def test_a_wrong_password(self) -> None:
+        for vectors in (self.SHA256_VECTORS, self.SHA512_VECTORS):
+            for (password, _), expected in vectors.items():
+                with self.subTest(stored=expected[:20]):
+                    self.assertFalse(_crypt.verify(f"{password}x", expected))
+
+    def test_it_is_not_a_bare_digest_of_the_salted_password(self) -> None:
+        """
+        The question comes up every time: a bare sha512 of the same bytes is unrelated
+        to what $6$ produces
+        """
+        import base64
+        import hashlib
+
+        stored = "$6$FGkY6bLp$FLRsAi6byimzKD0qdHddj.KT3zGYn0YAQb1fz92.0iRT7oOWSxlrqtRH5PsV2.O54EGWS.YTWcL/GI.oOsXnx."
+        naive = base64.b64encode(hashlib.sha512(b"FGkY6bLpgood").digest()).decode("ascii")
+
+        self.assertTrue(_crypt.verify("good", stored))
+        self.assertNotIn(naive[:16], stored)
+
+    def test_an_empty_password(self) -> None:
+        """
+        Accepted by the algorithm, refused by the openssl command line, so it is pinned
+        here against what the system libcrypt answers
+        """
+        stored = "$6$Salt1234$9n2q0b/5q6BDYjbIfWDCa.pc2ztIkmadTm8vExXDkHruVrP.WuCs9mStfH56AOQ5w5ElMFcccmPpMKoRHrgaE."
+        self.assertTrue(_crypt.verify("", stored))
+        self.assertFalse(_crypt.verify("x", stored))
+
+    def test_the_salt_is_capped_at_sixteen_characters(self) -> None:
+        """
+        Which is why the vectors above spell the truncated salt in what they expect
+        """
+        self.assertEqual(
+            _crypt.sha_crypt("Hello world!", "$5$rounds=10000$saltstringsaltstring$x", _crypt.Scheme.SHA256),
+            "$5$rounds=10000$saltstringsaltst$3xv.VbSHBb41AL9AvLeujZkZRBAwqFMz2.opqey6IcA",
+        )
+
+    def test_too_many_rounds_are_refused(self) -> None:
+        """
+        The format allows up to 999999999, which one login would turn into minutes of
+        CPU: a password file must not be able to do that to its own server.
+
+        The two hashes below are published vectors of the algorithm, so this pins the
+        cap against something a real tool produces rather than against a fabrication
+        """
+        published = (
+            "$5$rounds=123456$asaltof16chars..$gP3VQ/6X7UUEW3HkBn2w1side3HAKIoTayg/w8DHzX0",
+            (
+                "$6$rounds=123456$asaltof16chars..$BtCwjqMJGx5hrJhZywWvt0RLE8uZ4oPwc"
+                "elCjmw2kSYu.Ec6ycULevoBK25fs2xXgMNrCzIMVcgEJAstJeonj1"
+            ),
+        )
+        for stored in published:
+            with self.subTest(stored=stored[:20]), self.assertRaises(_crypt.UnsupportedHash) as context:
+                _crypt.verify("a short string", stored)
+
+            self.assertIn(str(_crypt.MAX_ROUNDS), str(context.exception))
+
+    def test_the_accepted_maximum_still_works(self) -> None:
+        stored = _crypt.sha_crypt(
+            "hunter2", f"$5$rounds={_crypt.MAX_ROUNDS}$Salt1234$x", _crypt.Scheme.SHA256
+        )
+        self.assertTrue(_crypt.verify("hunter2", stored))
+
+
+class BcryptTest(unittest.TestCase):
+    """
+    Tests the optional bcrypt support
+    """
+
+    @unittest.skipIf(importlib.util.find_spec("bcrypt") is None, "bcrypt is not installed")
+    def test_it_is_verified_when_the_module_is_there(self) -> None:
+        """
+        The hash is produced by bcrypt itself: what is under test is that the format is
+        recognized and handed over, not the bcrypt algorithm
+        """
+        import bcrypt
+
+        stored = bcrypt.hashpw(b"hunter2", bcrypt.gensalt(4, b"2b")).decode("ascii")
+
+        self.assertEqual(_crypt.classify(stored), _crypt.Scheme.BCRYPT)
+        self.assertTrue(_crypt.verify("hunter2", stored))
+        self.assertFalse(_crypt.verify("wrong", stored))
+
+    @unittest.skipIf(importlib.util.find_spec("bcrypt") is not None, "bcrypt is installed")
+    def test_it_is_refused_with_a_remediation(self) -> None:
+        """
+        A pure-Python Blowfish would be hand-rolled cryptography and tens of times too
+        slow, so the answer is a message naming what to do instead
+        """
+        for prefix in ("$2a$", "$2b$", "$2y$"):
+            with self.subTest(prefix=prefix), self.assertRaises(_crypt.UnsupportedHash) as context:
+                _crypt.classify(f"{prefix}04$abcdefghijklmnopqrstuv")
+
+            self.assertIn("bcrypt", str(context.exception))
+            self.assertIn("htpasswd -5", str(context.exception))
+
+
+class DummyHashTest(unittest.TestCase):
+    """
+    The dummy hashes are what gives an unknown user the cost of a known one
+    """
+
+    def test_every_dummy_is_a_hash_of_the_dummy_password(self) -> None:
+        """
+        Pinned rather than computed at import time, so they are checked here
+        """
+        for scheme in (
+            _crypt.Scheme.SHA1,
+            _crypt.Scheme.APR1,
+            _crypt.Scheme.SHA256,
+            _crypt.Scheme.SHA512,
+            _crypt.Scheme.PLAINTEXT,
+        ):
+            with self.subTest(scheme=scheme):
+                stored = _crypt.dummy_hash(scheme)
+                self.assertEqual(_crypt.classify(stored), scheme)
+                self.assertTrue(_crypt.verify(_crypt.DUMMY_PASSWORD, stored))
+
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/security/test_decorators.py
+++ b/tests/security/test_decorators.py
@@ -1,0 +1,612 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests the declarative security decorators.
+
+Every decorator reads as "allow only": any-of within one, all-of when stacked, and a
+method-level declaration replaces a class-level one entirely.
+
+:author: Thomas Calmant
+"""
+
+import asyncio
+import inspect
+import unittest
+from typing import Any
+
+from pelix.security import (
+    ANONYMOUS,
+    AccessDenied,
+    AuthenticationRequired,
+    Authorization,
+    Permission,
+    Subject,
+    get_current_subject,
+    run_as,
+)
+from pelix.security.decorators import (
+    SECURITY_ATTRIBUTE,
+    AllowAll,
+    AllowAuthenticated,
+    AllowGroup,
+    AllowPermission,
+    AllowRole,
+    DenyAll,
+    RunAs,
+    set_authorization,
+)
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# ------------------------------------------------------------------------------
+
+ALICE = Subject("alice", frozenset({"dev"}), frozenset({"admin"}), authenticated=True)
+BOB = Subject("bob", frozenset({"ops"}), frozenset({"operator"}), authenticated=True)
+UNAUTHENTICATED = Subject("carol", frozenset({"dev"}), frozenset({"admin"}))
+
+# ------------------------------------------------------------------------------
+
+
+class FakeAuthorization(Authorization):
+    """
+    Grants a fixed set of permission specifications, to whoever asks
+    """
+
+    def __init__(self, *granted: str) -> None:
+        self.granted = [Permission.parse(spec) for spec in granted]
+        self.calls: list[tuple[Permission, Subject | None]] = []
+
+    def is_permitted(self, permission: Permission, subject: Subject | None = None) -> bool:
+        self.calls.append((permission, subject))
+        return any(grant.implies(permission) for grant in self.granted)
+
+    def check_permitted(self, permission: Permission, subject: Subject | None = None) -> None:
+        if not self.is_permitted(permission, subject):
+            raise AccessDenied(str(permission))
+
+    def has_role(self, role: str, subject: Subject | None = None) -> bool:
+        return role in (subject or get_current_subject()).roles
+
+    def in_group(self, group: str, subject: Subject | None = None) -> bool:
+        return group in (subject or get_current_subject()).groups
+
+
+def run(coroutine: Any) -> Any:
+    """
+    Runs a coroutine to completion, keeping the context of the caller: the whole point
+    of the asynchronous wrappers is that they see the subject published around them
+    """
+    return asyncio.run(coroutine)
+
+
+# ------------------------------------------------------------------------------
+
+
+class AllowAuthenticatedTest(unittest.TestCase):
+    """
+    Tests @AllowAuthenticated
+    """
+
+    def setUp(self) -> None:
+        @AllowAuthenticated
+        def target() -> str:
+            return "done"
+
+        self.target = target
+
+    def test_an_authenticated_subject_passes(self) -> None:
+        with run_as(ALICE):
+            self.assertEqual(self.target(), "done")
+
+    def test_anonymous_is_asked_for_credentials(self) -> None:
+        with self.assertRaises(AuthenticationRequired):
+            self.target()
+
+    def test_a_named_but_unauthenticated_subject_is_asked_too(self) -> None:
+        """
+        The flag decides, not the name: a subject carrying groups and roles it asserted
+        itself is still not authenticated
+        """
+        with run_as(UNAUTHENTICATED), self.assertRaises(AuthenticationRequired):
+            self.target()
+
+
+class AllowGroupTest(unittest.TestCase):
+    """
+    Tests @AllowGroup
+    """
+
+    def setUp(self) -> None:
+        @AllowGroup("dev", "release")
+        def target() -> str:
+            return "done"
+
+        self.target = target
+
+    def test_any_of_the_groups_is_enough(self) -> None:
+        with run_as(ALICE):
+            self.assertEqual(self.target(), "done")
+
+    def test_another_group_is_denied(self) -> None:
+        with run_as(BOB), self.assertRaises(AccessDenied):
+            self.target()
+
+    def test_anonymous_is_asked_for_credentials(self) -> None:
+        """
+        Not 403: a challenge may still help an anonymous caller
+        """
+        with self.assertRaises(AuthenticationRequired):
+            self.target()
+
+    def test_group_names_are_compared_exactly(self) -> None:
+        with run_as(Subject("dave", frozenset({"Dev"}), authenticated=True)), self.assertRaises(AccessDenied):
+            self.target()
+
+    def test_applied_bare_it_refuses_at_import_time(self) -> None:
+        """
+        Written without parentheses, the decorator would bind the function as the group
+        name and fail much later, with a message about __call__ arguments
+        """
+        with self.assertRaises(TypeError):
+
+            @AllowGroup  # ty: ignore[invalid-argument-type]
+            def target() -> None:
+                pass
+
+    def test_applied_with_no_name_it_refuses_at_import_time(self) -> None:
+        with self.assertRaises(TypeError):
+            AllowGroup()  # ty: ignore[missing-argument]
+
+
+class AllowRoleTest(unittest.TestCase):
+    """
+    Tests @AllowRole
+    """
+
+    def setUp(self) -> None:
+        @AllowRole("admin")
+        def target() -> str:
+            return "done"
+
+        self.target = target
+
+    def test_the_role_holder_passes(self) -> None:
+        with run_as(ALICE):
+            self.assertEqual(self.target(), "done")
+
+    def test_another_role_is_denied(self) -> None:
+        with run_as(BOB), self.assertRaises(AccessDenied):
+            self.target()
+
+    def test_applied_bare_it_refuses_at_import_time(self) -> None:
+        with self.assertRaises(TypeError):
+
+            @AllowRole  # ty: ignore[invalid-argument-type]
+            def target() -> None:
+                pass
+
+
+class AllowAllAndDenyAllTest(unittest.TestCase):
+    """
+    Tests the two extremes
+    """
+
+    def test_allow_all_narrows_nothing(self) -> None:
+        @AllowAll
+        def target() -> str:
+            return "done"
+
+        self.assertEqual(target(), "done")
+        with run_as(ALICE):
+            self.assertEqual(target(), "done")
+
+    def test_allow_all_returns_the_target_itself(self) -> None:
+        """
+        There is nothing to check, so there is nothing to wrap: only the mark matters
+        """
+
+        def original() -> None:
+            pass
+
+        self.assertIs(AllowAll(original), original)
+
+    def test_deny_all_denies_everyone(self) -> None:
+        @DenyAll
+        def target() -> None:
+            pass
+
+        with run_as(ALICE), self.assertRaises(AccessDenied):
+            target()
+
+    def test_deny_all_denies_anonymous_with_no_challenge(self) -> None:
+        """
+        AccessDenied and not AuthenticationRequired: no credential would help, so
+        offering a challenge would be a lie
+        """
+
+        @DenyAll
+        def target() -> None:
+            pass
+
+        with self.assertRaises(AccessDenied):
+            target()
+
+
+class AllowPermissionTest(unittest.TestCase):
+    """
+    Tests @AllowPermission, the only decorator which needs a service
+    """
+
+    def setUp(self) -> None:
+        self.authorization = FakeAuthorization("jobs.*")
+        set_authorization(self.authorization)
+        self.addCleanup(set_authorization, None)
+
+        @AllowPermission("jobs.submit")
+        def target() -> str:
+            return "done"
+
+        self.target = target
+
+    def test_a_granted_permission_passes(self) -> None:
+        with run_as(ALICE):
+            self.assertEqual(self.target(), "done")
+
+    def test_the_current_subject_is_the_one_checked(self) -> None:
+        with run_as(ALICE):
+            self.target()
+
+        self.assertEqual(self.authorization.calls[-1], (Permission("jobs.submit"), ALICE))
+
+    def test_a_refused_permission_denies(self) -> None:
+        @AllowPermission("config.write")
+        def target() -> None:
+            pass
+
+        with run_as(ALICE), self.assertRaises(AccessDenied):
+            target()
+
+    def test_the_specification_is_parsed_at_decoration_time(self) -> None:
+        with self.assertRaises(ValueError):
+
+            @AllowPermission(":queue-a")
+            def target() -> None:
+                pass
+
+    def test_a_scoped_permission_is_carried_through(self) -> None:
+        @AllowPermission("jobs.submit:queue-a")
+        def target() -> None:
+            pass
+
+        with run_as(ALICE):
+            target()
+
+        self.assertEqual(self.authorization.calls[-1][0], Permission("jobs.submit", "queue-a"))
+
+
+class FailClosedTest(unittest.TestCase):
+    """
+    With no authorization service published, @AllowPermission denies. The other
+    decorators keep working: they are pure context-variable operations
+    """
+
+    def setUp(self) -> None:
+        set_authorization(None)
+
+    def test_allow_permission_denies(self) -> None:
+        @AllowPermission("jobs.submit")
+        def target() -> None:
+            pass
+
+        with run_as(ALICE), self.assertRaises(AccessDenied):
+            target()
+
+    def test_the_denial_is_reported_once_per_permission(self) -> None:
+        """
+        One warning per distinct permission, not one per call
+        """
+
+        @AllowPermission("reported.once")
+        def target() -> None:
+            pass
+
+        with (
+            run_as(ALICE),
+            self.assertLogs("pelix.security.decorators", "WARNING") as logs,
+        ):
+            for _ in range(3):
+                with self.assertRaises(AccessDenied):
+                    target()
+
+            # Nothing else would be logged, so provoke a second, different warning
+            @AllowPermission("reported.too")
+            def other() -> None:
+                pass
+
+            with self.assertRaises(AccessDenied):
+                other()
+
+        self.assertEqual(len(logs.output), 2)
+        self.assertIn("reported.once", logs.output[0])
+        self.assertIn("reported.too", logs.output[1])
+
+    def test_the_other_decorators_still_work(self) -> None:
+        @AllowRole("admin")
+        def allowed() -> str:
+            return "done"
+
+        @AllowGroup("nobody")
+        def refused() -> None:
+            pass
+
+        with run_as(ALICE):
+            self.assertEqual(allowed(), "done")
+            with self.assertRaises(AccessDenied):
+                refused()
+
+
+class RunAsTest(unittest.TestCase):
+    """
+    Tests @RunAs
+    """
+
+    def test_the_body_runs_under_the_declared_identity(self) -> None:
+        @RunAs(BOB)
+        def target() -> Subject:
+            return get_current_subject()
+
+        self.assertEqual(target(), BOB)
+
+    def test_the_identity_is_taken_back_afterwards(self) -> None:
+        @RunAs(BOB)
+        def target() -> None:
+            pass
+
+        with run_as(ALICE):
+            target()
+            self.assertEqual(get_current_subject(), ALICE)
+
+        self.assertIs(get_current_subject(), ANONYMOUS)
+
+    def test_it_composes_with_a_check(self) -> None:
+        """
+        Stacked below @AllowRole, the check sees the caller and the body sees the
+        assumed identity: the order of the two decorators is what says which
+        """
+
+        @AllowRole("admin")
+        @RunAs(BOB)
+        def target() -> Subject:
+            return get_current_subject()
+
+        with run_as(ALICE):
+            self.assertEqual(target(), BOB)
+
+        with run_as(BOB), self.assertRaises(AccessDenied):
+            target()
+
+
+class AsyncFlavourTest(unittest.TestCase):
+    """
+    A synchronous wrapper around a coroutine function checks and restores the context
+    before the body ever runs, which turns @RunAs into a no-op looking correct. Both
+    flavours therefore ship from day one
+    """
+
+    def test_run_as_reaches_the_coroutine_body(self) -> None:
+        @RunAs(BOB)
+        async def target() -> Subject:
+            return get_current_subject()
+
+        self.assertEqual(run(target()), BOB)
+
+    def test_a_check_runs_before_the_coroutine_body(self) -> None:
+        calls: list[str] = []
+
+        @AllowRole("admin")
+        async def target() -> None:
+            calls.append("body")
+
+        async def main() -> None:
+            with run_as(BOB), self.assertRaises(AccessDenied):
+                await target()
+
+            with run_as(ALICE):
+                await target()
+
+        run(main())
+        self.assertEqual(calls, ["body"])
+
+    def test_the_wrapper_stays_a_coroutine_function(self) -> None:
+        @AllowRole("admin")
+        async def target() -> None:
+            pass
+
+        self.assertTrue(inspect.iscoroutinefunction(target))
+
+
+class StackingTest(unittest.TestCase):
+    """
+    Any-of within one decorator, all-of when stacked
+    """
+
+    def setUp(self) -> None:
+        @AllowGroup("dev")
+        @AllowRole("admin")
+        def target() -> str:
+            return "done"
+
+        self.target = target
+
+    def test_both_must_be_satisfied(self) -> None:
+        with run_as(ALICE):
+            self.assertEqual(self.target(), "done")
+
+    def test_one_of_the_two_is_not_enough(self) -> None:
+        for subject in (
+            Subject("dave", frozenset({"dev"}), authenticated=True),
+            Subject("erin", roles=frozenset({"admin"}), authenticated=True),
+        ):
+            with self.subTest(subject=subject.name), run_as(subject), self.assertRaises(AccessDenied):
+                self.target()
+
+    def test_both_declarations_are_recorded(self) -> None:
+        """
+        The shell must be able to answer "what does this method require" without
+        invoking anything
+        """
+        kinds = [declaration.kind for declaration in getattr(self.target, SECURITY_ATTRIBUTE)]
+        self.assertEqual(kinds, ["AllowRole", "AllowGroup"])
+
+
+class ClassScopeTest(unittest.TestCase):
+    """
+    A class-level decorator sets the default of the class body
+    """
+
+    def test_it_applies_to_the_public_methods_of_the_body(self) -> None:
+        @AllowRole("admin")
+        class Service:
+            def public(self) -> str:
+                return "done"
+
+        with run_as(ALICE):
+            self.assertEqual(Service().public(), "done")
+
+        with run_as(BOB), self.assertRaises(AccessDenied):
+            Service().public()
+
+    def test_it_leaves_the_underscore_names_alone(self) -> None:
+        """
+        Without that rule a class-level @DenyAll would wrap __init__ and present as a
+        construction error rather than an authorization one
+        """
+
+        @DenyAll
+        class Service:
+            def __init__(self) -> None:
+                self.built = True
+
+            def _helper(self) -> str:
+                return "helper"
+
+            def public(self) -> None:
+                pass
+
+        service = Service()
+        self.assertTrue(service.built)
+        self.assertEqual(service._helper(), "helper")
+        with self.assertRaises(AccessDenied):
+            service.public()
+
+    def test_a_method_declaration_replaces_the_class_default(self) -> None:
+        @DenyAll
+        class Service:
+            @AllowRole("operator")
+            def narrowed(self) -> str:
+                return "narrowed"
+
+            def denied(self) -> None:
+                pass
+
+        with run_as(BOB):
+            self.assertEqual(Service().narrowed(), "narrowed")
+            with self.assertRaises(AccessDenied):
+                Service().denied()
+
+    def test_allow_all_overrides_the_class_default(self) -> None:
+        @DenyAll
+        class Service:
+            @AllowAll
+            def open(self) -> str:
+                return "open"
+
+        self.assertEqual(Service().open(), "open")
+
+    def test_it_does_not_reach_the_inherited_methods(self) -> None:
+        class Base:
+            def inherited(self) -> str:
+                return "inherited"
+
+        @DenyAll
+        class Service(Base):
+            def own(self) -> None:
+                pass
+
+        self.assertEqual(Service().inherited(), "inherited")
+        with self.assertRaises(AccessDenied):
+            Service().own()
+
+    def test_a_subclass_does_not_rewrite_its_parent(self) -> None:
+        """
+        functools.wraps copies __dict__ entries by reference, so a declaration list
+        appended in place would be shared. It is built fresh instead
+        """
+
+        class Base:
+            @AllowRole("admin")
+            def method(self) -> str:
+                return "base"
+
+        @AllowRole("operator")
+        class Child(Base):
+            def method(self) -> str:
+                return "child"
+
+        with run_as(ALICE):
+            self.assertEqual(Base().method(), "base")
+            with self.assertRaises(AccessDenied):
+                Child().method()
+
+        with run_as(BOB):
+            self.assertEqual(Child().method(), "child")
+            with self.assertRaises(AccessDenied):
+                Base().method()
+
+
+class MarkerTest(unittest.TestCase):
+    """
+    The mark is what a class default and the shell read, rather than the wrapper
+    """
+
+    def test_an_undecorated_callable_carries_nothing(self) -> None:
+        def target() -> None:
+            pass
+
+        self.assertFalse(hasattr(target, SECURITY_ATTRIBUTE))
+
+    def test_the_declaration_names_what_was_asked(self) -> None:
+        @AllowGroup("dev", "ops")
+        def target() -> None:
+            pass
+
+        declarations = getattr(target, SECURITY_ATTRIBUTE)
+        self.assertEqual(len(declarations), 1)
+        self.assertEqual(declarations[0].kind, "AllowGroup")
+        self.assertEqual(declarations[0].values, ("dev", "ops"))
+        self.assertEqual(repr(declarations[0]), "AllowGroup('dev', 'ops')")
+
+    def test_allow_all_marks_without_declaring(self) -> None:
+        @AllowAll
+        def target() -> None:
+            pass
+
+        self.assertEqual(getattr(target, SECURITY_ATTRIBUTE), [])
+
+    def test_the_wrapper_keeps_the_identity_of_its_target(self) -> None:
+        @AllowRole("admin")
+        def named_target() -> None:
+            """A docstring"""
+
+        self.assertEqual(named_target.__name__, "named_target")
+        self.assertEqual(named_target.__doc__, "A docstring")
+
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/security/test_htpasswd.py
+++ b/tests/security/test_htpasswd.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests the .htpasswd credential store and its .htgroup membership half.
+
+:author: Thomas Calmant
+"""
+
+import os
+import pathlib
+import tempfile
+import time
+import unittest
+
+import pelix.framework
+from pelix.ipopo.constants import use_ipopo
+from pelix.security import (
+    FACTORY_HTPASSWD,
+    PROP_HTPASSWD_FILE,
+    PROP_HTPASSWD_GROUPS,
+    PROP_HTPASSWD_PLAINTEXT,
+    AuthenticationFailed,
+    Subject,
+    UsernamePassword,
+    _crypt,
+)
+from pelix.security.htpasswd import HtpasswdStore, parse_htgroup, parse_htpasswd
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# "good", hashed with SHA-crypt over SHA-512
+GOOD_SHA512 = (
+    "$6$FGkY6bLp$FLRsAi6byimzKD0qdHddj.KT3zGYn0YAQb1fz92.0iRT7oOWSxlrqtRH5PsV2.O54EGWS.YTWcL/GI.oOsXnx."
+)
+
+# "good", hashed with the Apache MD5 construction
+GOOD_APR1 = "$apr1$FGkY6bLp$IKkCuz1P..KyQ0FL0L7Ir0"
+
+# "abc", as htpasswd -s writes it
+ABC_SHA1 = "{SHA}qZk+NkcGgWq6PiVxeFDCbJzQ2J0="
+
+# ------------------------------------------------------------------------------
+
+
+class ParseHtpasswdTest(unittest.TestCase):
+    """
+    Tests the parsing of a password file, which happens once at load rather than
+    entry by entry at login
+    """
+
+    def test_a_plain_file(self) -> None:
+        users, skipped = parse_htpasswd([f"thomas:{GOOD_SHA512}", f"batch:{GOOD_APR1}"], "test")
+
+        self.assertEqual(set(users), {"thomas", "batch"})
+        self.assertEqual(skipped, 0)
+
+    def test_comments_and_blank_lines(self) -> None:
+        users, skipped = parse_htpasswd(["# a comment", "", "   ", f"thomas:{GOOD_SHA512}"], "test")
+
+        self.assertEqual(set(users), {"thomas"})
+        self.assertEqual(skipped, 0)
+
+    def test_a_malformed_line_is_skipped(self) -> None:
+        with self.assertLogs("pelix.security.htpasswd", "WARNING"):
+            users, skipped = parse_htpasswd(["not-a-pair", f"thomas:{GOOD_SHA512}"], "test")
+
+        self.assertEqual(set(users), {"thomas"})
+        self.assertEqual(skipped, 1)
+
+    def test_an_unsupported_entry_leaves_the_user_absent(self) -> None:
+        """
+        Absent rather than present and unverifiable, and reported with its file and
+        line number so that the operator meets it at deploy time
+        """
+        lines = [f"thomas:{GOOD_SHA512}", "old:rEK1ecacw.rKc"]
+
+        with self.assertLogs("pelix.security.htpasswd", "WARNING") as logs:
+            users, skipped = parse_htpasswd(lines, "/etc/pelix/.htpasswd")
+
+        self.assertNotIn("old", users)
+        self.assertEqual(skipped, 1)
+        self.assertIn("/etc/pelix/.htpasswd:2", logs.output[0])
+        self.assertIn("old", logs.output[0])
+
+    def test_a_hash_is_never_logged(self) -> None:
+        """
+        A warning names what the entry is and where it is, never what it holds
+        """
+        with self.assertLogs("pelix.security.htpasswd", "WARNING") as logs:
+            parse_htpasswd(["old:rEK1ecacw.rKc", f"weak:{ABC_SHA1}"], "test")
+
+        for message in logs.output:
+            self.assertNotIn("rEK1ecacw.rKc", message)
+            self.assertNotIn("qZk+", message)
+
+    def test_a_weak_scheme_is_reported(self) -> None:
+        with self.assertLogs("pelix.security.htpasswd", "WARNING") as logs:
+            users, _ = parse_htpasswd([f"weak:{ABC_SHA1}"], "test")
+
+        # Reported, but kept: it exists in the wild, and refusing it locks people out
+        self.assertIn("weak", users)
+        self.assertIn("htpasswd -5", logs.output[0])
+
+    def test_plaintext_is_refused_by_default(self) -> None:
+        with self.assertLogs("pelix.security.htpasswd", "WARNING") as logs:
+            users, skipped = parse_htpasswd(["thomas:hunter2"], "test")
+
+        self.assertEqual(users, {})
+        self.assertEqual(skipped, 1)
+        self.assertIn(PROP_HTPASSWD_PLAINTEXT, logs.output[0])
+
+    def test_plaintext_is_accepted_when_asked_for(self) -> None:
+        """
+        "Support plaintext" and "refuse unknown formats" are the same branch with
+        opposite defaults
+        """
+        with self.assertLogs("pelix.security.htpasswd", "WARNING"):
+            users, skipped = parse_htpasswd(["thomas:hunter2"], "test", allow_plaintext=True)
+
+        self.assertEqual(users, {"thomas": "hunter2"})
+        self.assertEqual(skipped, 0)
+
+    def test_user_names_are_kept_verbatim(self) -> None:
+        """
+        Which is what Apache itself does with these files: on this point the store is
+        format-correct by doing nothing
+        """
+        users, _ = parse_htpasswd([f"Thomas:{GOOD_SHA512}"], "test")
+
+        self.assertIn("Thomas", users)
+        self.assertNotIn("thomas", users)
+
+
+class ParseHtgroupTest(unittest.TestCase):
+    """
+    Tests the parsing of a group file
+    """
+
+    def test_a_plain_file(self) -> None:
+        groups = parse_htgroup(["dev-leads: thomas", "ops: batch thomas"], "test")
+
+        self.assertEqual(groups["thomas"], {"dev-leads", "ops"})
+        self.assertEqual(groups["batch"], {"ops"})
+
+    def test_comments_and_blank_lines(self) -> None:
+        groups = parse_htgroup(["# groupname: user", "", "ops: batch"], "test")
+
+        self.assertEqual(set(groups), {"batch"})
+
+    def test_a_group_may_span_several_lines(self) -> None:
+        groups = parse_htgroup(["ops: batch", "ops: thomas"], "test")
+
+        self.assertEqual(groups["batch"], {"ops"})
+        self.assertEqual(groups["thomas"], {"ops"})
+
+    def test_a_malformed_line_is_skipped(self) -> None:
+        with self.assertLogs("pelix.security.htpasswd", "WARNING"):
+            groups = parse_htgroup(["not-a-group", "ops: batch"], "test")
+
+        self.assertEqual(set(groups), {"batch"})
+
+    def test_an_empty_group_holds_nobody(self) -> None:
+        self.assertEqual(parse_htgroup(["empty:"], "test"), {})
+
+
+# ------------------------------------------------------------------------------
+
+
+class StoreTestCase(unittest.TestCase):
+    """
+    Common fixture: a temporary folder holding the two files, and a store over them
+    """
+
+    framework: pelix.framework.Framework
+
+    users_content = f"thomas:{GOOD_SHA512}\nbatch:{GOOD_APR1}\n"
+    groups_content = "dev-leads: thomas\nops: thomas batch\n"
+
+    def setUp(self) -> None:
+        self.folder = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(self.__remove_folder)
+
+        self.users_file = self.folder / ".htpasswd"
+        self.groups_file = self.folder / ".htgroup"
+        self.users_file.write_text(self.users_content)
+        self.groups_file.write_text(self.groups_content)
+        self.users_file.chmod(0o600)
+
+        self.framework = pelix.framework.create_framework(("pelix.ipopo.core", "pelix.security.htpasswd"))
+        self.addCleanup(self.framework.delete, True)
+        self.framework.start()
+
+    def __remove_folder(self) -> None:
+        for path in self.folder.iterdir():
+            path.unlink()
+
+        self.folder.rmdir()
+
+    def instantiate(self, **properties: object) -> HtpasswdStore:
+        """
+        Instantiates the store over the temporary files
+
+        :param properties: Extra component properties
+        :return: The store instance
+        """
+        with use_ipopo(self.framework.get_bundle_context()) as ipopo:
+            return ipopo.instantiate(
+                FACTORY_HTPASSWD,
+                "test-htpasswd",
+                {
+                    PROP_HTPASSWD_FILE: str(self.users_file),
+                    PROP_HTPASSWD_GROUPS: str(self.groups_file),
+                    **properties,
+                },
+            )
+
+
+class AuthenticateTest(StoreTestCase):
+    """
+    Tests the Authenticator half
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.store = self.instantiate()
+
+    def test_a_good_password(self) -> None:
+        subject = self.store.authenticate(UsernamePassword("thomas", "good"))
+
+        assert subject is not None
+        self.assertEqual(subject.name, "thomas")
+
+    def test_every_supported_scheme_of_the_file(self) -> None:
+        for name in ("thomas", "batch"):
+            with self.subTest(user=name):
+                self.assertIsNotNone(self.store.authenticate(UsernamePassword(name, "good")))
+
+    def test_a_wrong_password_stops_the_loop(self) -> None:
+        """
+        A store which knows the user and rejects the password raises rather than
+        abstaining: that is what closes the credential oracle
+        """
+        with self.assertRaises(AuthenticationFailed):
+            self.store.authenticate(UsernamePassword("thomas", "wrong"))
+
+    def test_an_unknown_user_abstains(self) -> None:
+        """
+        Abstain and not fail: raising for a name this store never heard of would stop
+        the loop and make every lower-ranked store unreachable for that name
+        """
+        self.assertIsNone(self.store.authenticate(UsernamePassword("nobody", "good")))
+
+    def test_another_kind_of_credentials_abstains(self) -> None:
+        class OtherCredentials:
+            KIND = "token"
+
+        self.assertIsNone(self.store.authenticate(OtherCredentials()))  # ty: ignore[invalid-argument-type]
+
+    def test_user_names_are_compared_exactly(self) -> None:
+        self.assertIsNone(self.store.authenticate(UsernamePassword("Thomas", "good")))
+
+    def test_passwords_are_not_transformed(self) -> None:
+        """
+        The stored hash was computed over exact bytes, so touching the candidate would
+        break every non-ASCII password
+        """
+        for password in ("GOOD", " good", "good "):
+            with self.subTest(password=password), self.assertRaises(AuthenticationFailed):
+                self.store.authenticate(UsernamePassword("thomas", password))
+
+
+class TimingTest(StoreTestCase):
+    """
+    An unknown user must not answer instantly while a known one burns thousands of
+    rounds: the difference alone enumerates the file
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.store = self.instantiate()
+
+    def measure(self, username: str) -> float:
+        start = time.perf_counter()
+        for _ in range(5):
+            try:
+                self.store.authenticate(UsernamePassword(username, "some-password"))
+            except AuthenticationFailed:
+                pass
+
+        return time.perf_counter() - start
+
+    def test_an_unknown_user_costs_about_what_a_known_one_costs(self) -> None:
+        known = self.measure("thomas")
+        unknown = self.measure("nobody")
+
+        # Generous, because a wall clock in a test suite is not a measuring instrument:
+        # what it catches is the shape of the leak, an instant answer against a
+        # thousands-of-rounds one
+        self.assertGreater(unknown, known / 4, "The unknown user answered far too quickly")
+
+    def test_the_dummy_hash_follows_the_file(self) -> None:
+        """
+        The fake check uses the most expensive scheme the file really holds, or it would
+        be visibly cheaper than a real one
+        """
+        self.assertEqual(self.store._dummy_scheme, _crypt.Scheme.SHA512)
+
+
+class MembershipTest(StoreTestCase):
+    """
+    Tests the MembershipProvider half
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.store = self.instantiate()
+
+    def test_the_groups_of_a_user(self) -> None:
+        self.assertEqual(set(self.store.get_groups(Subject("thomas"))), {"dev-leads", "ops"})
+        self.assertEqual(set(self.store.get_groups(Subject("batch"))), {"ops"})
+
+    def test_an_unknown_user_has_no_group(self) -> None:
+        self.assertEqual(set(self.store.get_groups(Subject("nobody"))), set())
+
+    def test_a_password_file_grants_no_role(self) -> None:
+        """
+        Roles are the policy's job
+        """
+        self.assertEqual(set(self.store.get_roles(Subject("thomas"))), set())
+
+    def test_without_a_group_file_nobody_has_a_group(self) -> None:
+        with use_ipopo(self.framework.get_bundle_context()) as ipopo:
+            ipopo.kill("test-htpasswd")
+
+        store = self.instantiate(**{PROP_HTPASSWD_GROUPS: ""})
+        self.assertEqual(set(store.get_groups(Subject("thomas"))), set())
+
+
+class ReloadTest(StoreTestCase):
+    """
+    Tests what a reload does, and above all what a failed one does not do
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.store = self.instantiate()
+
+    def test_a_new_user_is_picked_up(self) -> None:
+        self.users_file.write_text(f"{self.users_content}added:{GOOD_SHA512}\n")
+        self.store.reload()
+
+        self.assertIsNotNone(self.store.authenticate(UsernamePassword("added", "good")))
+
+    def test_a_removed_user_is_revoked(self) -> None:
+        """
+        A successfully parsed file with a user removed does revoke that user: that is
+        the whole point of the distinction below
+        """
+        self.users_file.write_text(f"batch:{GOOD_APR1}\n")
+        self.store.reload()
+
+        self.assertIsNone(self.store.authenticate(UsernamePassword("thomas", "good")))
+
+    def test_an_empty_file_keeps_the_previous_table(self) -> None:
+        """
+        Far more likely a partial write than an intentional revocation of everyone.
+        This is the one place where failing closed is the wrong instinct
+        """
+        self.users_file.write_text("")
+
+        with self.assertLogs("pelix.security.htpasswd", "ERROR"):
+            self.store.reload()
+
+        self.assertIsNotNone(self.store.authenticate(UsernamePassword("thomas", "good")))
+
+    def test_an_unreadable_file_keeps_the_previous_table(self) -> None:
+        self.users_file.unlink()
+
+        with self.assertLogs("pelix.security.htpasswd", "ERROR"):
+            self.store.reload()
+
+        self.assertIsNotNone(self.store.authenticate(UsernamePassword("thomas", "good")))
+
+        # Put it back, so that the cleanup finds what it expects
+        self.users_file.write_text(self.users_content)
+
+    def test_a_file_with_no_usable_entry_keeps_the_previous_table(self) -> None:
+        self.users_file.write_text("thomas:rEK1ecacw.rKc\n")
+
+        with self.assertLogs("pelix.security.htpasswd", "WARNING"):
+            self.store.reload()
+
+        self.assertIsNotNone(self.store.authenticate(UsernamePassword("thomas", "good")))
+
+    def test_the_group_file_is_reloaded_too(self) -> None:
+        self.groups_file.write_text("release: thomas\n")
+        self.store.reload()
+
+        self.assertEqual(set(self.store.get_groups(Subject("thomas"))), {"release"})
+
+
+class FileInstallTest(StoreTestCase):
+    """
+    Tests the whiteboard registration on the File Install service
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.store = self.instantiate()
+
+    def test_the_watched_folder_is_the_one_holding_the_file(self) -> None:
+        self.assertEqual(self.store._watched_folder, str(self.folder))
+
+    def test_a_change_to_a_watched_file_reloads(self) -> None:
+        self.users_file.write_text(f"{self.users_content}added:{GOOD_SHA512}\n")
+        self.store.folder_change(str(self.folder), [], [".htpasswd"], [])
+
+        self.assertIsNotNone(self.store.authenticate(UsernamePassword("added", "good")))
+
+    def test_a_change_to_a_neighbour_is_ignored(self) -> None:
+        """
+        File Install watches a whole folder and reports base names, so everything living
+        next to the two files of interest has to be filtered out
+        """
+        self.users_file.write_text(f"{self.users_content}added:{GOOD_SHA512}\n")
+        self.store.folder_change(str(self.folder), ["something-else.txt"], [], [])
+
+        self.assertIsNone(self.store.authenticate(UsernamePassword("added", "good")))
+
+    def test_the_whole_round_trip(self) -> None:
+        """
+        With the File Install bundle started, writing the file is enough. Without it,
+        the file is simply read once at validation: that is documented degradation, not
+        a failure, and every other test here runs in that mode
+        """
+        context = self.framework.get_bundle_context()
+        context.install_bundle("pelix.services.fileinstall").start()
+
+        # The watcher diffs on (mtime, checksum), so the content really has to change
+        self.users_file.write_text(f"{self.users_content}added:{GOOD_SHA512}\n")
+
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            if self.store.authenticate(UsernamePassword("added", "good")) is not None:
+                return
+
+            time.sleep(0.2)
+
+        self.fail("The store was not reloaded within 10 seconds")
+
+
+class ConfigurationTest(StoreTestCase):
+    """
+    Tests the properties of the component
+    """
+
+    def test_no_password_file_leaves_the_component_invalid(self) -> None:
+        with use_ipopo(self.framework.get_bundle_context()) as ipopo:
+            ipopo.instantiate(FACTORY_HTPASSWD, "no-file", {})
+            details = ipopo.get_instance_details("no-file")
+
+        self.assertNotEqual(details["state"], 1, "The component must not be valid without a file")
+
+    def test_the_accepted_credential_kinds_are_published(self) -> None:
+        """
+        Declaring them is mandatory: the core selects an authenticator on that property
+        """
+        self.instantiate()
+
+        reference = self.framework.get_bundle_context().get_service_reference("pelix.security.authenticator")
+        assert reference is not None
+        self.assertEqual(tuple(reference.get_property("pelix.security.credentials")), ("password",))
+
+    def test_the_file_mode_is_reported(self) -> None:
+        if os.name != "posix":
+            self.skipTest("POSIX file modes only")
+
+        self.users_file.chmod(0o644)
+
+        with self.assertLogs("pelix.security.htpasswd", "WARNING") as logs:
+            self.instantiate()
+
+        self.assertTrue(any("chmod 600" in message for message in logs.output))
+
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/security/test_imports.py
+++ b/tests/security/test_imports.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Pins the import rule of the Pelix security package: it must stay importable with no
+framework running, which is what keeps a credential store reusable outside HTTP and
+keeps most of the layer unit-testable with a bare import.
+
+:author: Thomas Calmant
+"""
+
+import subprocess
+import sys
+import unittest
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+# Modules which must not be dragged in by the security package
+FORBIDDEN = ("pelix.framework", "pelix.http", "pelix.ipopo")
+
+# ------------------------------------------------------------------------------
+
+
+def imported_modules(module: str) -> set[str]:
+    """
+    Imports the given module in a fresh interpreter and returns the Pelix modules it
+    loaded.
+
+    :param module: Name of the module to import
+    :return: The names of the loaded ``pelix`` modules
+    """
+    script = f"import {module}, sys; print(' '.join(m for m in sys.modules if m.startswith('pelix')))"
+    output = subprocess.run([sys.executable, "-c", script], capture_output=True, check=True, text=True).stdout
+    return set(output.split())
+
+
+class ImportRuleTest(unittest.TestCase):
+    """
+    Tests what importing the security package pulls in
+    """
+
+    def test_the_package_imports_almost_nothing(self) -> None:
+        """
+        The whole runtime import list is the standard library plus pelix.constants
+        """
+        self.assertEqual(imported_modules("pelix.security"), {"pelix", "pelix.constants", "pelix.security"})
+
+    def test_the_package_pulls_no_framework(self) -> None:
+        """
+        Stated separately from the exact set above, because this is the rule and the set
+        is only how it is checked today
+        """
+        loaded = imported_modules("pelix.security")
+        for forbidden in FORBIDDEN:
+            with self.subTest(module=forbidden):
+                self.assertNotIn(forbidden, loaded)
+
+    def test_the_decorators_pull_no_ipopo(self) -> None:
+        """
+        They must work on a plain class, with no component model behind it
+        """
+        self.assertNotIn("pelix.ipopo", imported_modules("pelix.security.decorators"))
+
+    def test_no_module_pulls_pelix_http(self) -> None:
+        """
+        The direction which is forbidden: pelix.http may depend on pelix.security, so
+        that a Protocol signature can name a Subject, but never the other way round. It
+        is what keeps a credential store usable by the shell, or by a message broker
+        client, rather than only by a servlet
+        """
+        for module in (
+            "pelix.security.decorators",
+            "pelix.security._crypt",
+            "pelix.security.core",
+            "pelix.security.htpasswd",
+            "pelix.security.policy",
+        ):
+            with self.subTest(module=module):
+                self.assertNotIn("pelix.http", imported_modules(module))
+
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/security/test_policy.py
+++ b/tests/security/test_policy.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python
+# -- Content-Encoding: UTF-8 --
+"""
+Tests the TOML policy file: roles granted from users and groups, permissions granted
+to roles.
+
+:author: Thomas Calmant
+"""
+
+import pathlib
+import tempfile
+import unittest
+
+import pelix.framework
+from pelix.ipopo.constants import use_ipopo
+from pelix.security import (
+    ANONYMOUS,
+    FACTORY_ALLOW_ALL,
+    FACTORY_POLICY_FILE,
+    PROP_POLICY_FILE,
+    Decision,
+    Permission,
+    Subject,
+)
+from pelix.security.policy import PolicyError, PolicyFile, PolicyTable
+
+# ------------------------------------------------------------------------------
+
+__version_info__ = (3, 2, 2)
+__version__ = ".".join(str(x) for x in __version_info__)
+
+POLICY = """
+[roles.admin]
+users  = ["thomas"]
+groups = ["dev-leads"]
+
+[roles.operator]
+groups = ["dev", "ops"]
+
+[permissions]
+admin    = ["jobs.*", "config.*"]
+operator = ["jobs.read", "jobs.submit"]
+"""
+
+LOGGER = "pelix.security.policy"
+
+# ------------------------------------------------------------------------------
+
+
+class PolicyTableRolesTest(unittest.TestCase):
+    """
+    Tests the roles half: a role is granted from the facts an identity source asserted
+    """
+
+    def setUp(self) -> None:
+        with self.assertLogs(LOGGER, "WARNING"):
+            self.table = PolicyTable(POLICY, "policy.toml")
+
+    def test_a_role_granted_by_user_name(self) -> None:
+        self.assertIn("admin", self.table.get_roles(Subject("thomas")))
+
+    def test_a_role_granted_by_group(self) -> None:
+        self.assertEqual(
+            self.table.get_roles(Subject("someone", frozenset({"ops"}))), frozenset({"operator"})
+        )
+
+    def test_any_of_the_groups_is_enough(self) -> None:
+        for group in ("dev", "ops"):
+            with self.subTest(group=group):
+                self.assertIn("operator", self.table.get_roles(Subject("someone", frozenset({group}))))
+
+    def test_both_routes_accumulate(self) -> None:
+        subject = Subject("thomas", frozenset({"dev"}))
+        self.assertEqual(self.table.get_roles(subject), frozenset({"admin", "operator"}))
+
+    def test_nobody_gets_a_role_by_default(self) -> None:
+        self.assertEqual(self.table.get_roles(Subject("stranger")), frozenset())
+        self.assertEqual(self.table.get_roles(ANONYMOUS), frozenset())
+
+    def test_names_are_compared_exactly(self) -> None:
+        """
+        The whole reason the format is TOML: its keys are case-sensitive, so the loader
+        cannot fold what the rest of the layer forbids anything to fold
+        """
+        self.assertEqual(self.table.get_roles(Subject("Thomas")), frozenset())
+        self.assertEqual(self.table.get_roles(Subject("x", frozenset({"Dev-Leads"}))), frozenset())
+
+    def test_the_policy_asserts_no_group(self) -> None:
+        """
+        A group is a fact from an identity source, never something a policy invents
+        """
+        component = PolicyFile()
+        self.assertEqual(list(component.get_groups(Subject("thomas"))), [])
+
+
+class PolicyTablePermissionsTest(unittest.TestCase):
+    """
+    Tests the permissions half
+    """
+
+    def setUp(self) -> None:
+        with self.assertLogs(LOGGER, "WARNING"):
+            self.table = PolicyTable(POLICY, "policy.toml")
+
+    def permit(self, roles: set[str], spec: str) -> Decision:
+        return self.table.is_permitted(Subject("x", roles=frozenset(roles)), Permission.parse(spec))
+
+    def test_a_granted_permission(self) -> None:
+        self.assertIs(self.permit({"operator"}, "jobs.submit"), Decision.PERMIT)
+
+    def test_a_wildcard_grant(self) -> None:
+        for spec in ("jobs.submit", "jobs.queue.drain", "config.write"):
+            with self.subTest(spec=spec):
+                self.assertIs(self.permit({"admin"}, spec), Decision.PERMIT)
+
+    def test_a_permission_of_another_role(self) -> None:
+        self.assertIs(self.permit({"operator"}, "config.write"), Decision.ABSTAIN)
+
+    def test_no_role_grants_nothing(self) -> None:
+        self.assertIs(self.permit(set(), "jobs.read"), Decision.ABSTAIN)
+
+    def test_it_never_denies(self) -> None:
+        """
+        The format expresses grants only, so this authorizer can never veto what a
+        looser one permits. That matters as soon as a second one is registered
+        """
+        for roles in (set(), {"admin"}, {"operator"}, {"unknown"}):
+            for spec in ("jobs.submit", "nothing.at.all", "config.write"):
+                with self.subTest(roles=roles, spec=spec):
+                    self.assertIsNot(self.permit(roles, spec), Decision.DENY)
+
+    def test_an_empty_permissions_table_denies_everything(self) -> None:
+        """
+        Safe, and it is what "there is no implicit all-grant" means
+        """
+        table = PolicyTable("[permissions]\n")
+        self.assertIs(
+            table.is_permitted(Subject("x", roles=frozenset({"admin"})), Permission("jobs.read")),
+            Decision.ABSTAIN,
+        )
+
+
+class PolicyTableWarningsTest(unittest.TestCase):
+    """
+    Tests what the loader reports.
+
+    Every name is matched exactly against what an identity source provided, so a
+    misspelling denies silently. These two shapes are what most misspellings produce
+    """
+
+    def test_every_wildcard_is_named(self) -> None:
+        with self.assertLogs(LOGGER, "WARNING") as logs:
+            PolicyTable('[roles.admin]\nusers = ["thomas"]\n\n[permissions]\nadmin = ["jobs.*", "*"]\n')
+
+        wildcards = [message for message in logs.output if "wildcard" in message]
+        self.assertEqual(len(wildcards), 2)
+        self.assertTrue(any("'*'" in message for message in wildcards))
+
+    def test_a_role_granted_but_given_no_permission(self) -> None:
+        with self.assertLogs(LOGGER, "WARNING") as logs:
+            PolicyTable('[roles.typo]\nusers = ["thomas"]\n\n[permissions]\n')
+
+        self.assertIn("typo", logs.output[0])
+        self.assertIn("no permission", logs.output[0])
+
+    def test_a_permission_granted_to_nobody(self) -> None:
+        with self.assertLogs(LOGGER, "WARNING") as logs:
+            PolicyTable('[roles]\n\n[permissions]\ntypo = ["jobs.read"]\n')
+
+        self.assertIn("typo", logs.output[0])
+        self.assertIn("granted to nobody", logs.output[0])
+
+    def test_a_coherent_policy_is_quiet(self) -> None:
+        policy = '[roles.admin]\nusers = ["thomas"]\n\n[permissions]\nadmin = ["jobs.read"]\n'
+
+        with self.assertNoLogs(LOGGER, "WARNING"):
+            PolicyTable(policy)
+
+
+class PolicyShapeTest(unittest.TestCase):
+    """
+    tomllib guarantees well-formed TOML, not a well-shaped policy: it would happily
+    return {"roles": {"admin": 12}}
+    """
+
+    def test_the_shape_failures(self) -> None:
+        cases = {
+            "roles is not a table": "roles = 12\n",
+            "a role is not a table": "[roles]\nadmin = 12\n",
+            "an unknown key": '[roles.admin]\nusers = ["a"]\nmembers = ["b"]\n',
+            "users is not a list": '[roles.admin]\nusers = "thomas"\n',
+            "users holds something else": "[roles.admin]\nusers = [12]\n",
+            "permissions is not a table": "permissions = 12\n",
+            "a permission list is not a list": '[permissions]\nadmin = "jobs.read"\n',
+        }
+        for name, text in cases.items():
+            with self.subTest(case=name), self.assertRaises(PolicyError):
+                PolicyTable(text)
+
+    def test_a_malformed_permission_is_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            PolicyTable('[roles.admin]\nusers = ["a"]\n\n[permissions]\nadmin = [":queue-a"]\n')
+
+    def test_a_duplicate_key_is_a_parse_error(self) -> None:
+        """
+        Which an INI file would have kept silently. Granting a role twice is a mistake
+        """
+        with self.assertRaises(Exception) as context:
+            PolicyTable('[permissions]\nadmin = ["a"]\nadmin = ["b"]\n')
+
+        self.assertNotIsInstance(context.exception, PolicyError)
+
+    def test_an_empty_document_is_valid(self) -> None:
+        table = PolicyTable("")
+        self.assertEqual(table.get_roles(Subject("thomas")), frozenset())
+
+
+# ------------------------------------------------------------------------------
+
+
+class PolicyComponentTest(unittest.TestCase):
+    """
+    Tests the component around the table: validation and reload
+    """
+
+    framework: pelix.framework.Framework
+
+    def setUp(self) -> None:
+        self.folder = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(self.__remove_folder)
+
+        self.policy_file = self.folder / "policy.toml"
+        self.policy_file.write_text(POLICY)
+
+        self.framework = pelix.framework.create_framework(("pelix.ipopo.core", "pelix.security.policy"))
+        self.addCleanup(self.framework.delete, True)
+        self.framework.start()
+
+    def __remove_folder(self) -> None:
+        for path in self.folder.iterdir():
+            path.unlink()
+
+        self.folder.rmdir()
+
+    def instantiate(self) -> PolicyFile:
+        with use_ipopo(self.framework.get_bundle_context()) as ipopo, self.assertLogs(LOGGER, "WARNING"):
+            return ipopo.instantiate(
+                FACTORY_POLICY_FILE, "test-policy", {PROP_POLICY_FILE: str(self.policy_file)}
+            )
+
+    def test_it_loads_at_validation(self) -> None:
+        component = self.instantiate()
+
+        self.assertEqual(set(component.get_roles(Subject("thomas"))), {"admin"})
+        self.assertIs(
+            component.is_permitted(Subject("x", roles=frozenset({"admin"})), Permission("jobs.submit")),
+            Decision.PERMIT,
+        )
+
+    def test_no_policy_file_leaves_the_component_invalid(self) -> None:
+        with use_ipopo(self.framework.get_bundle_context()) as ipopo:
+            ipopo.instantiate(FACTORY_POLICY_FILE, "no-file", {})
+            details = ipopo.get_instance_details("no-file")
+
+        self.assertNotEqual(details["state"], 1, "The component must not be valid without a file")
+
+    def test_a_change_is_picked_up(self) -> None:
+        component = self.instantiate()
+        self.policy_file.write_text('[roles.admin]\nusers = ["someone-else"]\n\n[permissions]\n')
+
+        with self.assertLogs(LOGGER, "WARNING"):
+            component.reload()
+
+        self.assertEqual(set(component.get_roles(Subject("thomas"))), set())
+        self.assertEqual(set(component.get_roles(Subject("someone-else"))), {"admin"})
+
+    def test_a_broken_file_keeps_the_previous_policy(self) -> None:
+        """
+        Higher-stakes than a bad user-list reload, because a truncated file must not be
+        mistaken for a policy which genuinely grants nothing
+        """
+        component = self.instantiate()
+        self.policy_file.write_text("[roles.admin\nusers = [")
+
+        with self.assertLogs(LOGGER, "ERROR"):
+            component.reload()
+
+        self.assertEqual(set(component.get_roles(Subject("thomas"))), {"admin"})
+
+    def test_a_badly_shaped_file_keeps_the_previous_policy(self) -> None:
+        component = self.instantiate()
+        self.policy_file.write_text("[roles]\nadmin = 12\n")
+
+        with self.assertLogs(LOGGER, "ERROR"):
+            component.reload()
+
+        self.assertEqual(set(component.get_roles(Subject("thomas"))), {"admin"})
+
+    def test_an_empty_file_keeps_the_previous_policy(self) -> None:
+        component = self.instantiate()
+        self.policy_file.write_text("")
+
+        with self.assertLogs(LOGGER, "ERROR"):
+            component.reload()
+
+        self.assertEqual(set(component.get_roles(Subject("thomas"))), {"admin"})
+
+    def test_an_unreadable_file_keeps_the_previous_policy(self) -> None:
+        component = self.instantiate()
+        self.policy_file.unlink()
+
+        with self.assertLogs(LOGGER, "ERROR"):
+            component.reload()
+
+        self.assertEqual(set(component.get_roles(Subject("thomas"))), {"admin"})
+        self.policy_file.write_text(POLICY)
+
+    def test_the_watched_folder_is_the_one_holding_the_file(self) -> None:
+        self.assertEqual(self.instantiate()._watched_folder, str(self.folder))
+
+    def test_a_change_reported_by_file_install_reloads(self) -> None:
+        component = self.instantiate()
+        self.policy_file.write_text('[roles.admin]\nusers = ["someone-else"]\n\n[permissions]\n')
+
+        with self.assertLogs(LOGGER, "WARNING"):
+            component.folder_change(str(self.folder), [], ["policy.toml"], [])
+
+        self.assertEqual(set(component.get_roles(Subject("someone-else"))), {"admin"})
+
+    def test_a_change_to_a_neighbour_is_ignored(self) -> None:
+        component = self.instantiate()
+        self.policy_file.write_text('[roles.admin]\nusers = ["someone-else"]\n\n[permissions]\n')
+        component.folder_change(str(self.folder), ["other.toml"], [], [])
+
+        self.assertEqual(set(component.get_roles(Subject("thomas"))), {"admin"})
+
+
+class AllowAllTest(unittest.TestCase):
+    """
+    Tests the deliberate escape hatch
+    """
+
+    framework: pelix.framework.Framework
+
+    def setUp(self) -> None:
+        self.framework = pelix.framework.create_framework(("pelix.ipopo.core", "pelix.security.policy"))
+        self.addCleanup(self.framework.delete, True)
+        self.framework.start()
+
+    def test_it_warns_when_it_validates(self) -> None:
+        """
+        You cannot get permissive by accident, and you cannot get it quietly either
+        """
+        with use_ipopo(self.framework.get_bundle_context()) as ipopo, self.assertLogs(LOGGER, "WARNING"):
+            ipopo.instantiate(FACTORY_ALLOW_ALL, "allow-all", {})
+
+    def test_it_permits_everything(self) -> None:
+        with use_ipopo(self.framework.get_bundle_context()) as ipopo, self.assertLogs(LOGGER, "WARNING"):
+            authorizer = ipopo.instantiate(FACTORY_ALLOW_ALL, "allow-all", {})
+
+        for subject in (ANONYMOUS, Subject("thomas", authenticated=True)):
+            with self.subTest(subject=subject.name):
+                self.assertIs(authorizer.is_permitted(subject, Permission("anything")), Decision.PERMIT)
+
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_threadpool.py
+++ b/tests/test_threadpool.py
@@ -8,6 +8,7 @@ Cached thread pool tests
 
 # ------------------------------------------------------------------------------
 
+import contextvars
 import threading
 import time
 import unittest
@@ -22,6 +23,8 @@ __version_info__ = (3, 2, 2)
 __version__ = ".".join(str(x) for x in __version_info__)
 
 T = TypeVar("T")
+
+_TEST_VAR: contextvars.ContextVar[str] = contextvars.ContextVar("test_var")
 
 # ------------------------------------------------------------------------------
 
@@ -527,6 +530,86 @@ class ThreadPoolTest(unittest.TestCase):
             self.assertLessEqual(self.pool._ThreadPool__nb_threads, self.pool._max_threads)  # type: ignore
 
         self.pool.join()
+
+
+# ------------------------------------------------------------------------------
+
+
+class ThreadPoolContextTest(unittest.TestCase):
+    """
+    Tests the propagation of context variables through the thread pool
+    """
+
+    def setUp(self) -> None:
+        """
+        Sets up the test
+        """
+        self.pool = threadpool.ThreadPool(1)
+        self.pool.start()
+
+        # The context of the main thread outlives a test method: give the variable a
+        # known value, and take it back afterwards
+        self._token = _TEST_VAR.set("initial")
+
+    def tearDown(self) -> None:
+        """
+        Cleans up the test
+        """
+        self.pool.stop()
+        _TEST_VAR.reset(self._token)
+
+    def testContextIsPropagated(self) -> None:
+        """
+        The task must see the context variables of its caller
+        """
+        _TEST_VAR.set("caller")
+        future = self.pool.enqueue(_TEST_VAR.get, "unset")
+        self.assertEqual(future.result(2), "caller")
+
+    def testContextIsCapturedAtEnqueue(self) -> None:
+        """
+        The value seen by the task is the one set when it was queued, not the one
+        set while it was waiting in the queue
+        """
+        _TEST_VAR.set("at-enqueue")
+        blocker = EventData[Any]()
+        self.pool.enqueue(blocker.wait, 5)
+        future = self.pool.enqueue(_TEST_VAR.get, "unset")
+
+        # The task is queued behind the blocker: change the value in the meantime
+        _TEST_VAR.set("after-enqueue")
+        blocker.set(None)
+
+        self.assertEqual(future.result(5), "at-enqueue")
+
+    def testTaskDoesNotLeakIntoTheNextOne(self) -> None:
+        """
+        A pool thread is reused: what a task sets must not reach the next one
+        """
+        future = self.pool.enqueue(_TEST_VAR.set, "leaked")
+        future.result(2)
+
+        future = self.pool.enqueue(_TEST_VAR.get, "unset")
+        self.assertEqual(future.result(2), "initial")
+
+    def testTaskDoesNotAffectTheCaller(self) -> None:
+        """
+        A task runs in a copy: what it sets must not reach the caller either
+        """
+        _TEST_VAR.set("caller")
+        self.pool.enqueue(_TEST_VAR.set, "task").result(2)
+        self.assertEqual(_TEST_VAR.get(), "caller")
+
+    def testHandMadeTaskKeepsTheOldBehaviour(self) -> None:
+        """
+        A task built without a context (the stop sentinel is one) is still executed,
+        in the context of the worker thread, as every task used to be
+        """
+        task = threadpool._QueuedTask(_TEST_VAR.get, ("unset",), {}, threadpool.FutureResult())
+        self.assertIsNone(task.context)
+
+        self.pool._queue.put(task)
+        self.assertEqual(task.future.result(2), "unset")
 
 
 # ------------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -206,6 +206,76 @@ wheels = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/75/4aa9f5a4d40d762892066ba1046000b329c7cd58e888a6db878019b282dc/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7edda91d5ab52b15636d9c30da87d2cc84f426c72b9dba7a9b4fe142ba11f534", size = 271180, upload-time = "2025-09-25T19:50:38.575Z" },
+    { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791, upload-time = "2025-09-25T19:50:39.913Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746, upload-time = "2025-09-25T19:50:43.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375, upload-time = "2025-09-25T19:50:45.43Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -850,11 +920,15 @@ version = "3.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "jsonrpclib-pelix" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.optional-dependencies]
 aiohttp = [
     { name = "aiohttp" },
+]
+bcrypt = [
+    { name = "bcrypt" },
 ]
 etcd2 = [
     { name = "osgiservicebridge" },
@@ -898,6 +972,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.13.5,<3.15.0" },
+    { name = "bcrypt", marker = "extra == 'bcrypt'", specifier = ">=4.1,<6.0" },
     { name = "grpcio", marker = "extra == 'rsa'", specifier = ">=1.80,<1.84" },
     { name = "grpcio-tools", marker = "extra == 'rsa'", specifier = ">=1.80,<1.84" },
     { name = "jsonrpclib-pelix", specifier = ">=0.4.3,<1.3.0" },
@@ -910,9 +985,10 @@ requires-dist = [
     { name = "redis", marker = "extra == 'redis'", specifier = ">=7.4,<8.2" },
     { name = "slixmpp", marker = "python_full_version >= '3.11' and extra == 'xmpp'", specifier = "~=1.15.0" },
     { name = "slixmpp", marker = "python_full_version < '3.11' and extra == 'xmpp'", specifier = "~=1.12.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "zeroconf", marker = "extra == 'zeroconf'", specifier = ">=0.148,<0.151" },
 ]
-provides-extras = ["aiohttp", "etcd2", "mqtt", "redis", "rsa", "xmpp", "zeroconf", "zookeeper", "yaml"]
+provides-extras = ["aiohttp", "bcrypt", "etcd2", "mqtt", "redis", "rsa", "xmpp", "zeroconf", "zookeeper", "yaml"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
- Added `pelix.security`: principals, permissions, policy engine, password hashing, htpasswd authentication and decorators 
- Added authentication/authorization hooks to `pelix.http` servlet dispatch
- HTTP Servlet paths are now case-sensitive
